### PR TITLE
Delete plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ In the **Secret** field, enter a JWT secret key.
 
 ## Scripts
 
-The following scripts are included in `package.json`:
+The following scripts are included in the `package.json` file:
 
 ```json
 "scripts": {

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -481,3 +481,38 @@ describe("PATCH /api/plots/plot/:plot_id", () => {
     })
   })
 })
+
+
+describe("DELETE /api/plots/plot/:plot_id", () => {
+
+  test("DELETE:204 Deletes the plot with the given plot_id", async () => {
+
+    await request(app)
+      .delete("/api/plots/plot/1")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(204)
+
+    const { body } = await request(app)
+      .get("/api/plots/plot/1")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(404)
+
+    expect(body).toMatchObject({
+      message: "Not Found",
+      details: "Plot not found"
+    })
+  })
+
+  test("DELETE:403 Responds with a warning when the authenticated user attempts to delete another user's plot", async () => {
+
+    const { body } = await request(app)
+      .delete("/api/plots/plot/2")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(403)
+
+    expect(body).toMatchObject({
+      message: "Forbidden",
+      details: "Permission to delete plot data denied"
+    })
+  })
+})

--- a/src/__tests__/utils/db-query-utils.test.ts
+++ b/src/__tests__/utils/db-query-utils.test.ts
@@ -1,7 +1,7 @@
 import data from "../../db/data/test-data/data-index"
 import { db } from "../../db"
 import { seed } from "../../db/seeding/seed"
-import { checkPlotNameConflict, getPlotOwnerId, getValidPlotTypes, verifyPlotOwner } from "../../utils/db-query-utils"
+import { checkPlotNameConflict, getPlotOwnerId, getValidPlotTypes } from "../../utils/db-query-utils"
 
 
 beforeEach(() => seed(data))
@@ -60,35 +60,6 @@ describe("getPlotOwnerId", () => {
       status: 404,
       message: "Not Found",
       details: "Plot not found"
-    })
-
-  })
-})
-
-
-describe("verifyPlotOwner", () => {
-
-  test("Returns a plot object when the plot belongs to the current user", async () => {
-
-    const result = await verifyPlotOwner(1, 1, "Test")
-
-    expect(result).toMatchObject({
-      plot_id: 1,
-      owner_id: 1,
-      name: "John's Garden",
-      type: "garden",
-      description: "A vegetable garden",
-      location: "Farmville",
-      area: 100
-    })
-  })
-
-  test("When the plot does not belong to the current user, the promise is rejected", async () => {
-
-    await expect(verifyPlotOwner(1, 2, "Permission denied")).rejects.toMatchObject({
-      status: 403,
-      message: "Forbidden",
-      details: "Permission denied"
     })
   })
 })

--- a/src/controllers/plot-controllers.ts
+++ b/src/controllers/plot-controllers.ts
@@ -1,5 +1,5 @@
 import { RequestHandler } from "express"
-import { insertPlotByOwner, selectPlotByPlotId, selectPlotsByOwner, updatePlotByPlotId } from "../models/plot-models"
+import { insertPlotByOwner, removePlotByPlotId, selectPlotByPlotId, selectPlotsByOwner, updatePlotByPlotId } from "../models/plot-models"
 
 
 export const getPlotsByOwner: RequestHandler = async (req, res, next) => {
@@ -58,6 +58,21 @@ export const patchPlotByPlotId: RequestHandler = async (req, res, next) => {
   try {
     const plot = await updatePlotByPlotId(authUserId, +plot_id, req.body)
     res.status(200).send({ plot })
+  } catch (err) {
+    next(err)
+  }
+}
+
+
+export const deletePlotByPlotId: RequestHandler = async (req, res, next) => {
+
+  const authUserId: number = req.body.user.user_id
+
+  const { plot_id } = req.params
+
+  try {
+    await removePlotByPlotId(authUserId, +plot_id)
+    res.status(204).send()
   } catch (err) {
     next(err)
   }

--- a/src/models/user-models.ts
+++ b/src/models/user-models.ts
@@ -51,6 +51,21 @@ export const updateUserByUsername = async (authUsername: string, username: strin
 }
 
 
+export const removeUserByUsername = async (authUsername: string, username: string): Promise<undefined> => {
+
+  await verifyPermission(authUsername, username, "Permission to delete user data denied")
+
+  const result = await db.query(`
+    DELETE FROM users
+    WHERE username = $1
+    RETURNING *;
+    `,
+    [username])
+
+  await verifyResult(!result.rowCount, "User not found")
+}
+
+
 export const changePasswordByUsername = async (authUsername: string, username: string, password: string): Promise<SecureUser> => {
 
   await verifyPermission(authUsername, username, "Permission to edit password denied")
@@ -71,19 +86,4 @@ export const changePasswordByUsername = async (authUsername: string, username: s
   await verifyResult(!result.rowCount, "User not found")
 
   return result.rows[0]
-}
-
-
-export const removeUserByUsername = async (authUsername: string, username: string): Promise<undefined> => {
-
-  await verifyPermission(authUsername, username, "Permission to delete user data denied")
-
-  const result = await db.query(`
-    DELETE FROM users
-    WHERE username = $1
-    RETURNING *;
-    `,
-    [username])
-
-  await verifyResult(!result.rowCount, "User not found")
 }

--- a/src/models/user-models.ts
+++ b/src/models/user-models.ts
@@ -51,7 +51,7 @@ export const updateUserByUsername = async (authUsername: string, username: strin
 }
 
 
-export const removeUserByUsername = async (authUsername: string, username: string): Promise<undefined> => {
+export const removeUserByUsername = async (authUsername: string, username: string): Promise<void> => {
 
   await verifyPermission(authUsername, username, "Permission to delete user data denied")
 

--- a/src/routes/plots-router.ts
+++ b/src/routes/plots-router.ts
@@ -1,6 +1,6 @@
 import { Router } from "express"
 import { verifyToken } from "../middleware/authentication"
-import { getPlotByPlotId, getPlotsByOwner, patchPlotByPlotId, postPlotByOwner } from "../controllers/plot-controllers"
+import { deletePlotByPlotId, getPlotByPlotId, getPlotsByOwner, patchPlotByPlotId, postPlotByOwner } from "../controllers/plot-controllers"
 
 
 export const plotsRouter = Router()
@@ -404,3 +404,22 @@ plotsRouter.route("/plots/plot/:plot_id")
  *                  example: "Plot name already exists"
  */
   .patch(verifyToken, patchPlotByPlotId)
+
+
+/**
+ * @swagger
+ * /api/plots/plot/{plot_id}:
+ *  delete:
+ *    security:
+ *      - bearerAuth: []
+ *    summary: Delete a plot from the database
+ *    description: Removes the plot and all associated data from the database. Permission is denied when the plot does not belong to the current user.
+ *    tags: [Plots]
+ *    parameters:
+ *      - in: path
+ *        name: plot_id
+ *        required: true
+ *        schema:
+ *          type: integer
+ */
+  .delete(verifyToken, deletePlotByPlotId)

--- a/src/routes/plots-router.ts
+++ b/src/routes/plots-router.ts
@@ -421,5 +421,21 @@ plotsRouter.route("/plots/plot/:plot_id")
  *        required: true
  *        schema:
  *          type: integer
+ *    responses:
+ *      204:
+ *        description: No Content
+ *      403:
+ *        description: Forbidden
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                message:
+ *                  type: string
+ *                  example: "Forbidden"
+ *                details:
+ *                  type: string
+ *                  example: "Permission to delete plot data denied"
  */
   .delete(verifyToken, deletePlotByPlotId)

--- a/src/utils/db-query-utils.ts
+++ b/src/utils/db-query-utils.ts
@@ -7,7 +7,7 @@ export const getValidPlotTypes = async (owner_id: number): Promise<string[]> => 
   const result = await db.query(`
     SELECT DISTINCT type
     FROM plots
-    WHERE owner_id = $1
+    WHERE owner_id = $1;
     `,
     [owner_id])
 
@@ -20,7 +20,7 @@ export const checkPlotNameConflict = async (owner_id: number, name: string): Pro
   const result = await db.query(`
     SELECT name
     FROM plots
-    WHERE owner_id = $1
+    WHERE owner_id = $1;
     `,
     [owner_id])
 
@@ -41,7 +41,7 @@ export const getPlotOwnerId = async (plot_id: number): Promise<number> => {
   const result = await db.query(`
     SELECT owner_id
     FROM plots
-    WHERE plot_id = $1
+    WHERE plot_id = $1;
     `,
     [plot_id])
 

--- a/src/utils/db-query-utils.ts
+++ b/src/utils/db-query-utils.ts
@@ -1,5 +1,4 @@
 import { db } from "../db"
-import { Plot } from "../types/plot-types"
 
 
 export const getValidPlotTypes = async (owner_id: number): Promise<string[]> => {
@@ -54,25 +53,4 @@ export const getPlotOwnerId = async (plot_id: number): Promise<number> => {
   }
 
   return result.rows[0].owner_id
-}
-
-
-export const verifyPlotOwner = async (plot_id: number, owner_id: number, details: string): Promise<Plot> => {
-
-  const result = await db.query(`
-    SELECT * FROM plots
-    WHERE plot_id = $1
-    AND owner_id = $2;
-    `,
-    [plot_id, owner_id])
-
-  if (!result.rowCount) {
-    return Promise.reject({
-      status: 403,
-      message: "Forbidden",
-      details
-    })
-  }
-
-  return result.rows[0]
 }


### PR DESCRIPTION
### Router

- Set up router
- Added JSDoc annotations

### Controller

- Set up controller

### Plot Models

- Added `removePlotByPlotId` model to delete plots
- Added `verifyResult` calls to models (may not be needed with auth in place but there as a backup)

### Utils

- Removed redundant `verifyPlotOwner` database query util

### Tests

- Added tests for the DELETE /api/plots/:owner_id/:plot_id endpoint