### PR TITLE
Status code fix

### DIFF
--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -72,6 +72,19 @@ describe("GET /api/plots/:owner_id", () => {
     expect(body.plots).toHaveLength(0)
   })
 
+  test("GET:400 Responds with an error message when the owner_id is not a number", async () => {
+
+    const { body } = await request(app)
+      .get("/api/plots/example")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject({
+      message: "Bad Request",
+      details: "Invalid parameter"
+    })
+  })
+
   test("GET:403 Responds with a warning when the authenticated user attempts to retrieve another user's plot data", async () => {
 
     const { body } = await request(app)
@@ -89,19 +102,6 @@ describe("GET /api/plots/:owner_id", () => {
 
     const { body } = await request(app)
       .get("/api/plots/999")
-      .set("Authorization", `Bearer ${token}`)
-      .expect(404)
-
-    expect(body).toMatchObject({
-      message: "Not Found",
-      details: "User not found"
-    })
-  })
-
-  test("GET:404 Responds with an error message when the owner_id is not a number", async () => {
-
-    const { body } = await request(app)
-      .get("/api/plots/plot")
       .set("Authorization", `Bearer ${token}`)
       .expect(404)
 
@@ -298,6 +298,29 @@ describe("POST /api/plots/:owner_id", () => {
     })
   })
 
+  test("POST:400 Responds with an error message when the owner_id is not a number", async () => {
+
+    const newPlot = {
+      owner_id: 1,
+      name: "John's Field",
+      type: "field",
+      description: "A large field",
+      location: "Wildwood",
+      area: 3000
+    }
+
+    const { body } = await request(app)
+      .post("/api/plots/example")
+      .send(newPlot)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject({
+      message: "Bad Request",
+      details: "Invalid parameter"
+    })
+  })
+
   test("POST:403 Responds with a warning when the authenticated user attempts to create a plot for another user", async () => {
 
     const newPlot = {
@@ -412,6 +435,19 @@ describe("GET /api/plots/plot/:plot_id", () => {
     })
   })
 
+  test("GET:400 Responds with an error message when the plot_id is not a number", async () => {
+
+    const { body } = await request(app)
+      .get("/api/plots/plot/example")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject({
+      message: "Bad Request",
+      details: "Invalid parameter"
+    })
+  })
+
   test("GET:403 Responds with a warning when the plot does not belong to the authenticated user", async () => {
 
     const { body } = await request(app)
@@ -429,19 +465,6 @@ describe("GET /api/plots/plot/:plot_id", () => {
 
     const { body } = await request(app)
       .get("/api/plots/plot/999")
-      .set("Authorization", `Bearer ${token}`)
-      .expect(404)
-
-    expect(body).toMatchObject({
-      message: "Not Found",
-      details: "Plot not found"
-    })
-  })
-
-  test("GET:404 Responds with an error message when the plot_id is not a number", async () => {
-
-    const { body } = await request(app)
-      .get("/api/plots/plot/example")
       .set("Authorization", `Bearer ${token}`)
       .expect(404)
 
@@ -553,6 +576,28 @@ describe("PATCH /api/plots/plot/:plot_id", () => {
     })
   })
 
+  test("PATCH:400 Responds with an error message when the plot_id is not a number", async () => {
+
+    const newDetails = {
+      name: "John's Homestead",
+      type: "homestead",
+      description: "A homestead",
+      location: "Farmville",
+      area: 1200
+    }
+
+    const { body } = await request(app)
+      .patch("/api/plots/plot/example")
+      .send(newDetails)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject({
+      message: "Bad Request",
+      details: "Invalid parameter"
+    })
+  })
+
   test("PATCH:403 Responds with a warning when the plot_id does not belong to the authenticated user", async () => {
 
     const newDetails = {
@@ -587,28 +632,6 @@ describe("PATCH /api/plots/plot/:plot_id", () => {
 
     const { body } = await request(app)
       .patch("/api/plots/plot/999")
-      .send(newDetails)
-      .set("Authorization", `Bearer ${token}`)
-      .expect(404)
-
-    expect(body).toMatchObject({
-      message: "Not Found",
-      details: "Plot not found"
-    })
-  })
-
-  test("PATCH:404 Responds with an error message when the plot_id is not a number", async () => {
-
-    const newDetails = {
-      name: "John's Homestead",
-      type: "homestead",
-      description: "A homestead",
-      location: "Farmville",
-      area: 1200
-    }
-
-    const { body } = await request(app)
-      .patch("/api/plots/plot/example")
       .send(newDetails)
       .set("Authorization", `Bearer ${token}`)
       .expect(404)
@@ -663,6 +686,19 @@ describe("DELETE /api/plots/plot/:plot_id", () => {
     })
   })
 
+  test("DELETE:400 Responds with an error message when the plot_id is not a number", async () => {
+
+    const { body } = await request(app)
+      .delete("/api/plots/plot/example")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject({
+      message: "Bad Request",
+      details: "Invalid parameter"
+    })
+  })
+
   test("DELETE:403 Responds with a warning when the authenticated user attempts to delete another user's plot", async () => {
 
     const { body } = await request(app)
@@ -680,19 +716,6 @@ describe("DELETE /api/plots/plot/:plot_id", () => {
 
     const { body } = await request(app)
       .delete("/api/plots/plot/999")
-      .set("Authorization", `Bearer ${token}`)
-      .expect(404)
-
-    expect(body).toMatchObject({
-      message: "Not Found",
-      details: "Plot not found"
-    })
-  })
-
-  test("DELETE:404 Responds with an error message when the plot_id is not a number", async () => {
-
-    const { body } = await request(app)
-      .delete("/api/plots/plot/example")
       .set("Authorization", `Bearer ${token}`)
       .expect(404)
 

--- a/src/__tests__/subdivisions.test.ts
+++ b/src/__tests__/subdivisions.test.ts
@@ -62,6 +62,19 @@ describe("GET /api/subdivisions/:plot_id", () => {
     expect(body.subdivisions).toHaveLength(0)
   })
 
+  test("GET:400 Responds with an error message when the plot_id is not a number", async () => {
+
+    const { body } = await request(app)
+      .get("/api/subdivisions/example")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject({
+      message: "Bad Request",
+      details: "Invalid parameter"
+    })
+  })
+
   test("GET:403 Responds with a warning when the authenticated user attempts to retrieve another user's subdivision data", async () => {
 
     const { body } = await request(app)
@@ -79,19 +92,6 @@ describe("GET /api/subdivisions/:plot_id", () => {
 
     const { body } = await request(app)
       .get("/api/subdivisions/999")
-      .set("Authorization", `Bearer ${token}`)
-      .expect(404)
-
-    expect(body).toMatchObject({
-      message: "Not Found",
-      details: "Plot not found"
-    })
-  })
-
-  test("GET:404 Responds with an error message when the plot_id is not a number", async () => {
-
-    const { body } = await request(app)
-      .get("/api/subdivisions/example")
       .set("Authorization", `Bearer ${token}`)
       .expect(404)
 
@@ -299,6 +299,28 @@ describe("POST /api/subdivisions/:plot_id", () => {
     })
   })
 
+  test("POST:400 Responds with an error message when the plot_id is not a number", async () => {
+
+    const newSubdivision = {
+      plot_id: 1,
+      name: "Wildflowers",
+      type: "flowerbed",
+      description: "Foxgloves and bluebells",
+      area: 2
+    }
+
+    const { body } = await request(app)
+      .post("/api/subdivisions/example")
+      .send(newSubdivision)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject({
+      message: "Bad Request",
+      details: "Invalid parameter"
+    })
+  })
+
   test("POST:403 Responds with a warning when the authenticated user attempts to create a subdivision for another user", async () => {
 
     const newSubdivision = {
@@ -365,28 +387,6 @@ describe("POST /api/subdivisions/:plot_id", () => {
     })
   })
 
-  test("POST:404 Responds with an error message when the plot_id is not a number", async () => {
-
-    const newSubdivision = {
-      plot_id: 1,
-      name: "Wildflowers",
-      type: "flowerbed",
-      description: "Foxgloves and bluebells",
-      area: 2
-    }
-
-    const { body } = await request(app)
-      .post("/api/subdivisions/example")
-      .send(newSubdivision)
-      .set("Authorization", `Bearer ${token}`)
-      .expect(404)
-
-    expect(body).toMatchObject({
-      message: "Not Found",
-      details: "Plot not found"
-    })
-  })
-
   test("POST:409 Responds with an error message when the subdivision name already exists for one of the given user's subdivisions of that plot", async () => {
 
     const newSubdivision = {
@@ -430,6 +430,19 @@ describe("GET /api/subdivisions/subdivision/:subdivision_id", () => {
     })
   })
 
+  test("GET:400 Responds with an error message when the subdivision is not a number", async () => {
+
+    const { body } = await request(app)
+      .get("/api/subdivisions/subdivision/example")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject({
+      message: "Bad Request",
+      details: "Invalid parameter"
+    })
+  })
+
   test("GET:403 Responds with a warning when the subdivision does not belong to the authenticated user", async () => {
 
     const { body } = await request(app)
@@ -447,19 +460,6 @@ describe("GET /api/subdivisions/subdivision/:subdivision_id", () => {
 
     const { body } = await request(app)
       .get("/api/subdivisions/subdivision/999")
-      .set("Authorization", `Bearer ${token}`)
-      .expect(404)
-
-    expect(body).toMatchObject({
-      message: "Not Found",
-      details: "Subdivision not found"
-    })
-  })
-
-  test("GET:404 Responds with an error message when the subdivision is not a number", async () => {
-
-    const { body } = await request(app)
-      .get("/api/subdivisions/subdivision/example")
       .set("Authorization", `Bearer ${token}`)
       .expect(404)
 
@@ -565,6 +565,27 @@ describe("PATCH /api/subdivisions/subdivision/:subdivision_id", () => {
     })
   })
 
+  test("PATCH:400 Responds with an error message when the subdivision_id is not a number", async () => {
+
+    const newDetails = {
+      name: "Root Vegetable Patch",
+      type: "vegetable patch",
+      description: "Turnips and radishes",
+      area: 20
+    }
+
+    const { body } = await request(app)
+      .patch("/api/subdivisions/subdivision/example")
+      .send(newDetails)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject({
+      message: "Bad Request",
+      details: "Invalid parameter"
+    })
+  })
+
   test("PATCH:403 Responds with a warning when the plot_id does not belong to the authenticated user", async () => {
 
     const newDetails = {
@@ -597,27 +618,6 @@ describe("PATCH /api/subdivisions/subdivision/:subdivision_id", () => {
 
     const { body } = await request(app)
       .patch("/api/subdivisions/subdivision/999")
-      .send(newDetails)
-      .set("Authorization", `Bearer ${token}`)
-      .expect(404)
-
-    expect(body).toMatchObject({
-      message: "Not Found",
-      details: "Subdivision not found"
-    })
-  })
-
-  test("PATCH:404 Responds with an error message when the subdivision_id is not a number", async () => {
-
-    const newDetails = {
-      name: "Root Vegetable Patch",
-      type: "vegetable patch",
-      description: "Turnips and radishes",
-      area: 20
-    }
-
-    const { body } = await request(app)
-      .patch("/api/subdivisions/subdivision/example")
       .send(newDetails)
       .set("Authorization", `Bearer ${token}`)
       .expect(404)
@@ -671,6 +671,19 @@ describe("DELETE /api/subdivisions/subdivision/:subdivision_id", () => {
     })
   })
 
+  test("DELETE:400 Responds with an error message when the subdivision_id is not a number", async () => {
+
+    const { body } = await request(app)
+      .delete("/api/subdivisions/subdivision/example")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject({
+      message: "Bad Request",
+      details: "Invalid parameter"
+    })
+  })
+
   test("DELETE:403 esponds with a warning when the authenticated user attempts to delete another user's subdivision", async () => {
 
     const { body } = await request(app)
@@ -688,19 +701,6 @@ describe("DELETE /api/subdivisions/subdivision/:subdivision_id", () => {
 
     const { body } = await request(app)
       .delete("/api/subdivisions/subdivision/999")
-      .set("Authorization", `Bearer ${token}`)
-      .expect(404)
-
-    expect(body).toMatchObject({
-      message: "Not Found",
-      details: "Subdivision not found"
-    })
-  })
-
-  test("DELETE:404 Responds with an error message when the subdivision_id is not a number", async () => {
-
-    const { body } = await request(app)
-      .delete("/api/subdivisions/subdivision/example")
       .set("Authorization", `Bearer ${token}`)
       .expect(404)
 

--- a/src/__tests__/utils/verification-utils.test.ts
+++ b/src/__tests__/utils/verification-utils.test.ts
@@ -21,17 +21,17 @@ describe("verifyPermission", () => {
 
 describe("verifyParamIsNumber", () => {
 
-  test("When the query parameter is not a number (NaN), the promise is rejected", () => {
+  test("When the value of the parameter is not a number (NaN), the promise is rejected", () => {
 
-    expect(verifyParamIsNumber(NaN, "Test")).rejects.toMatchObject({
-      status: 404,
-      message: "Not Found",
-      details: "Test"
+    expect(verifyParamIsNumber(NaN)).rejects.toMatchObject({
+      status: 400,
+      message: "Bad Request",
+      details: "Invalid parameter"
     })
   })
 
-  test("Returns undefined when the base value matches the target value", () => {
+  test("Returns undefined when the value of the parameter is a number", () => {
 
-    expect(verifyParamIsNumber(1, "Test")).toBeUndefined()
+    expect(verifyParamIsNumber(1)).toBeUndefined()
   })
 })

--- a/src/models/plot-models.ts
+++ b/src/models/plot-models.ts
@@ -8,6 +8,8 @@ import { verifyPermission, verifyParamIsNumber } from "../utils/verification-uti
 
 export const selectPlotsByOwner = async (authUserId: number, owner_id: number, { type }: QueryString.ParsedQs): Promise<Plot[]> => {
 
+  await verifyParamIsNumber(owner_id)
+
   await searchForUserId(owner_id)
 
   await verifyPermission(authUserId, owner_id, "Permission to view plot data denied")
@@ -36,6 +38,8 @@ export const selectPlotsByOwner = async (authUserId: number, owner_id: number, {
 
 
 export const insertPlotByOwner = async (authUserId: number, owner_id: number, plot: Plot): Promise<Plot> => {
+
+  await verifyParamIsNumber(owner_id)
 
   await searchForUserId(owner_id)
 
@@ -70,7 +74,7 @@ export const insertPlotByOwner = async (authUserId: number, owner_id: number, pl
 
 export const selectPlotByPlotId = async (authUserId: number, plot_id: number): Promise<Plot> => {
 
-  await verifyParamIsNumber(plot_id, "Plot not found")
+  await verifyParamIsNumber(plot_id)
 
   const owner_id = await getPlotOwnerId(plot_id)
 
@@ -88,7 +92,7 @@ export const selectPlotByPlotId = async (authUserId: number, plot_id: number): P
 
 export const updatePlotByPlotId = async (authUserId: number, plot_id: number, plot: Plot): Promise<Plot> => {
 
-  await verifyParamIsNumber(plot_id, "Plot not found")
+  await verifyParamIsNumber(plot_id)
 
   const owner_id = await getPlotOwnerId(plot_id)
 
@@ -134,7 +138,7 @@ export const updatePlotByPlotId = async (authUserId: number, plot_id: number, pl
 
 export const removePlotByPlotId = async (authUserId: number, plot_id: number): Promise<void> => {
 
-  await verifyParamIsNumber(plot_id, "Plot not found")
+  await verifyParamIsNumber(plot_id)
 
   const owner_id = await getPlotOwnerId(plot_id)
 

--- a/src/models/subdivision-models.ts
+++ b/src/models/subdivision-models.ts
@@ -8,7 +8,7 @@ import format from "pg-format"
 
 export const selectSubdivisionsByPlotId = async (authUserId: number, plot_id: number, { type }: QueryString.ParsedQs): Promise<Subdivision[]> => {
 
-  await verifyParamIsNumber(plot_id, "Plot not found")
+  await verifyParamIsNumber(plot_id)
 
   const owner_id = await getPlotOwnerId(plot_id)
 
@@ -39,7 +39,7 @@ export const selectSubdivisionsByPlotId = async (authUserId: number, plot_id: nu
 
 export const insertSubdivisionByPlotId = async (authUserId: number, plot_id: number, subdivision: Subdivision): Promise<Subdivision> => {
 
-  await verifyParamIsNumber(plot_id, "Plot not found")
+  await verifyParamIsNumber(plot_id)
 
   let owner_id = await getPlotOwnerId(plot_id)
 
@@ -76,7 +76,7 @@ export const insertSubdivisionByPlotId = async (authUserId: number, plot_id: num
 
 export const selectSubdivisionBySubdivisionId = async (authUserId: number, subdivision_id: number): Promise<Subdivision> => {
 
-  await verifyParamIsNumber(subdivision_id, "Subdivision not found")
+  await verifyParamIsNumber(subdivision_id)
 
   const plotId = await getSubdivisionPlotId(subdivision_id)
 
@@ -96,7 +96,7 @@ export const selectSubdivisionBySubdivisionId = async (authUserId: number, subdi
 
 export const updateSubdivisionBySubdivisionId = async (authUserId: number, subdivision_id: number, subdivision: Subdivision): Promise<Subdivision> => {
 
-  await verifyParamIsNumber(subdivision_id, "Subdivision not found")
+  await verifyParamIsNumber(subdivision_id)
 
   const plotId = await getSubdivisionPlotId(subdivision_id)
 
@@ -143,7 +143,7 @@ export const updateSubdivisionBySubdivisionId = async (authUserId: number, subdi
 
 export const removeSubdivisionBySubdivisionId = async (authUserId: number, subdivision_id: number): Promise<void> => {
 
-  await verifyParamIsNumber(subdivision_id, "Subdivision not found")
+  await verifyParamIsNumber(subdivision_id)
 
   const plotId = await getSubdivisionPlotId(subdivision_id)
 

--- a/src/routes/plots-router.ts
+++ b/src/routes/plots-router.ts
@@ -68,6 +68,19 @@ plotsRouter.route("/plots/:owner_id")
  *              type: array
  *              items:
  *                $ref: "#/components/schemas/Plot"
+ *      400:
+ *        description: Bad Request
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                message:
+ *                  type: string
+ *                  example: "Bad Request"
+ *                details:
+ *                  type: string
+ *                  example: "Invalid parameter"
  *      403:
  *        description: Forbidden
  *        content:
@@ -226,6 +239,19 @@ plotsRouter.route("/plots/plot/:plot_id")
  *          application/json:
  *            schema:
  *              $ref: "#/components/schemas/Plot"
+ *      400:
+ *        description: Bad Request
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                message:
+ *                  type: string
+ *                  example: "Bad Request"
+ *                details:
+ *                  type: string
+ *                  example: "Invalid parameter"
  *      403:
  *        description: Forbidden
  *        content:
@@ -374,6 +400,19 @@ plotsRouter.route("/plots/plot/:plot_id")
  *    responses:
  *      204:
  *        description: No Content
+ *      400:
+ *        description: Bad Request
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                message:
+ *                  type: string
+ *                  example: "Bad Request"
+ *                details:
+ *                  type: string
+ *                  example: "Invalid parameter"
  *      403:
  *        description: Forbidden
  *        content:

--- a/src/routes/plots-router.ts
+++ b/src/routes/plots-router.ts
@@ -6,37 +6,6 @@ import { deletePlotByPlotId, getPlotByPlotId, getPlotsByOwner, patchPlotByPlotId
 export const plotsRouter = Router()
 
 
-/**
- * @swagger
- * components:
- *  schemas:
- *    Plot:
- *      type: object
- *      properties:
- *        plot_id:
- *          type: integer
- *          example: 1
- *        owner_id:
- *          type: integer
- *          example: 1
- *        name:
- *          type: string
- *          example: John's Garden
- *        type:
- *          type: string
- *          example: garden
- *        description:
- *          type: string
- *          example: A vegetable garden
- *        location:
- *          type: string
- *          example: Farmville
- *        area:
- *          type: integer
- *          example: 100
- */
-
-
 plotsRouter.route("/plots/:owner_id")
 
 
@@ -73,40 +42,19 @@ plotsRouter.route("/plots/:owner_id")
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Bad Request"
- *                details:
- *                  type: string
- *                  example: "Invalid parameter"
+ *              $ref: "#/components/schemas/BadRequest"
  *      403:
  *        description: Forbidden
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Forbidden"
- *                details:
- *                  type: string
- *                  example: "Permission to view plot data denied"
+ *              $ref: "#/components/schemas/Forbidden"
  *      404:
  *        description: Not Found
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Not Found"
- *                details:
- *                  type: string
- *                  example: "No results found for that query"
+ *              $ref: "#/components/schemas/NotFound"
  */
   .get(verifyToken, getPlotsByOwner)
 
@@ -163,53 +111,25 @@ plotsRouter.route("/plots/:owner_id")
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Bad Request"
- *                details:
- *                  type: string
- *                  example: "Invalid text representation"
+ *              $ref: "#/components/schemas/BadRequest"
  *      403:
  *        description: Forbidden
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Forbidden"
- *                details:
- *                  type: string
- *                  example: "Permission to create plot denied"
+ *              $ref: "#/components/schemas/Forbidden"
  *      404:
  *        description: Not Found
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Not Found"
- *                details:
- *                  type: string
- *                  example: "User not found"
+ *              $ref: "#/components/schemas/NotFound"
  *      409:
  *        description: Conflict
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Conflict"
- *                details:
- *                  type: string
- *                  example: "Plot name already exists"
+ *              $ref: "#/components/schemas/Conflict"
  */
   .post(verifyToken, postPlotByOwner)
 
@@ -244,40 +164,19 @@ plotsRouter.route("/plots/plot/:plot_id")
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Bad Request"
- *                details:
- *                  type: string
- *                  example: "Invalid parameter"
+ *              $ref: "#/components/schemas/BadRequest"
  *      403:
  *        description: Forbidden
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Forbidden"
- *                details:
- *                  type: string
- *                  example: "Permission to view plot data denied"
+ *              $ref: "#/components/schemas/Forbidden"
  *      404:
  *        description: Not Found
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Not Found"
- *                details:
- *                  type: string
- *                  example: "Plot not found"
+ *              $ref: "#/components/schemas/NotFound"
  */
   .get(verifyToken, getPlotByPlotId)
 
@@ -331,53 +230,25 @@ plotsRouter.route("/plots/plot/:plot_id")
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Bad Request"
- *                details:
- *                  type: string
- *                  example: "Invalid text representation"
+ *              $ref: "#/components/schemas/BadRequest"
  *      403:
  *        description: Forbidden
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Forbidden"
- *                details:
- *                  type: string
- *                  example: "Permission to edit plot data denied"
+ *              $ref: "#/components/schemas/Forbidden"
  *      404:
  *        description: Not Found
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Not Found"
- *                details:
- *                  type: string
- *                  example: "Plot not found"
+ *              $ref: "#/components/schemas/NotFound"
  *      409:
  *        description: Conflict
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Conflict"
- *                details:
- *                  type: string
- *                  example: "Plot name already exists"
+ *              $ref: "#/components/schemas/Conflict"
  */
   .patch(verifyToken, patchPlotByPlotId)
 
@@ -405,39 +276,18 @@ plotsRouter.route("/plots/plot/:plot_id")
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Bad Request"
- *                details:
- *                  type: string
- *                  example: "Invalid parameter"
+ *              $ref: "#/components/schemas/BadRequest"
  *      403:
  *        description: Forbidden
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Forbidden"
- *                details:
- *                  type: string
- *                  example: "Permission to delete plot data denied"
+ *              $ref: "#/components/schemas/Forbidden"
  *      404:
  *        description: Not Found
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Not Found"
- *                details:
- *                  type: string
- *                  example: "Plot not found"
+ *              $ref: "#/components/schemas/NotFound"
  */
   .delete(verifyToken, deletePlotByPlotId)

--- a/src/routes/subdivisions-router.ts
+++ b/src/routes/subdivisions-router.ts
@@ -65,6 +65,19 @@ subdivisionsRouter.route("/subdivisions/:plot_id")
  *              type: array
  *              items:
  *                $ref: "#/components/schemas/Subdivision"
+ *      400:
+ *        description: Bad Request
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                message:
+ *                  type: string
+ *                  example: "Bad Request"
+ *                details:
+ *                  type: string
+ *                  example: "Invalid parameter"
  *      403:
  *        description: Forbidden
  *        content:
@@ -220,6 +233,19 @@ subdivisionsRouter.route("/subdivisions/subdivision/:subdivision_id")
  *          application/json:
  *            schema:
  *              $ref: "#/components/schemas/Subdivision"
+ *      400:
+ *        description: Bad Request
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                message:
+ *                  type: string
+ *                  example: "Bad Request"
+ *                details:
+ *                  type: string
+ *                  example: "Invalid parameter"
  *      403:
  *        description: Forbidden
  *        content:
@@ -365,6 +391,19 @@ subdivisionsRouter.route("/subdivisions/subdivision/:subdivision_id")
  *    responses:
  *      204:
  *        description: No Content
+ *      400:
+ *        description: Bad Request
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                message:
+ *                  type: string
+ *                  example: "Bad Request"
+ *                details:
+ *                  type: string
+ *                  example: "Invalid parameter"
  *      403:
  *        description: Forbidden
  *        content:

--- a/src/routes/subdivisions-router.ts
+++ b/src/routes/subdivisions-router.ts
@@ -6,34 +6,6 @@ import { deleteSubdivisionBySubdivisionId, getSubdivisionBySubdivisionId, getSub
 export const subdivisionsRouter = Router()
 
 
-/**
- * @swagger
- * components:
- *  schemas:
- *    Subdivision:
- *      type: object
- *      properties:
- *        subdivision_id:
- *          type: integer
- *          example: 1
- *        plot_id:
- *          type: integer
- *          example: 1
- *        name:
- *          type: string
- *          example: Root Vegetable Bed
- *        type:
- *          type: string
- *          example: bed
- *        description:
- *          type: string
- *          example: Carrots, beetroots, and parsnips
- *        area:
- *          type: integer
- *          example: 10
- */
-
-
 subdivisionsRouter.route("/subdivisions/:plot_id")
 
 
@@ -70,40 +42,19 @@ subdivisionsRouter.route("/subdivisions/:plot_id")
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Bad Request"
- *                details:
- *                  type: string
- *                  example: "Invalid parameter"
+ *              $ref: "#/components/schemas/BadRequest"
  *      403:
  *        description: Forbidden
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Forbidden"
- *                details:
- *                  type: string
- *                  example: "Permission to view plot subdivision data denied"
+ *              $ref: "#/components/schemas/Forbidden"
  *      404:
  *        description: Not Found
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Not Found"
- *                details:
- *                  type: string
- *                  example: "No results found for that query"
+ *              $ref: "#/components/schemas/NotFound"
  */
   .get(verifyToken, getSubdivisionsByPlotId)
 
@@ -157,53 +108,25 @@ subdivisionsRouter.route("/subdivisions/:plot_id")
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Bad Request"
- *                details:
- *                  type: string
- *                  example: "Invalid text representation"
+ *              $ref: "#/components/schemas/BadRequest"
  *      403:
  *        description: Forbidden
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Forbidden"
- *                details:
- *                  type: string
- *                  example: "Permission to create subdivision denied"
+ *              $ref: "#/components/schemas/Forbidden"
  *      404:
  *        description: Not Found
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Not Found"
- *                details:
- *                  type: string
- *                  example: "Plot not found"
+ *              $ref: "#/components/schemas/NotFound"
  *      409:
  *        description: Conflict
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Conflict"
- *                details:
- *                  type: string
- *                  example: "Subdivision name already exists"
+ *              $ref: "#/components/schemas/Conflict"
  */
   .post(verifyToken, postSubdivisionByPlotId)
 
@@ -238,40 +161,19 @@ subdivisionsRouter.route("/subdivisions/subdivision/:subdivision_id")
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Bad Request"
- *                details:
- *                  type: string
- *                  example: "Invalid parameter"
+ *              $ref: "#/components/schemas/BadRequest"
  *      403:
  *        description: Forbidden
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Forbidden"
- *                details:
- *                  type: string
- *                  example: "Permission to view subdivision data denied"
+ *              $ref: "#/components/schemas/Forbidden"
  *      404:
  *        description: Not Found
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Not Found"
- *                details:
- *                  type: string
- *                  example: "Subdivision not found"
+ *              $ref: "#/components/schemas/NotFound"
  */
   .get(verifyToken, getSubdivisionBySubdivisionId)
 
@@ -322,53 +224,25 @@ subdivisionsRouter.route("/subdivisions/subdivision/:subdivision_id")
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Bad Request"
- *                details:
- *                  type: string
- *                  example: "Invalid text representation"
+ *              $ref: "#/components/schemas/BadRequest"
  *      403:
  *        description: Forbidden
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Forbidden"
- *                details:
- *                  type: string
- *                  example: "Permission to edit subdivision data denied"
+ *              $ref: "#/components/schemas/Forbidden"
  *      404:
  *        description: Not Found
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Not Found"
- *                details:
- *                  type: string
- *                  example: "Subdivision not found"
+ *              $ref: "#/components/schemas/NotFound"
  *      409:
  *        description: Conflict
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Conflict"
- *                details:
- *                  type: string
- *                  example: "Subdivision name already exists"
+ *              $ref: "#/components/schemas/Conflict"
  */
   .patch(verifyToken, patchSubdivisionBySubdivisionId)
 
@@ -396,39 +270,18 @@ subdivisionsRouter.route("/subdivisions/subdivision/:subdivision_id")
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Bad Request"
- *                details:
- *                  type: string
- *                  example: "Invalid parameter"
+ *              $ref: "#/components/schemas/BadRequest"
  *      403:
  *        description: Forbidden
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Forbidden"
- *                details:
- *                  type: string
- *                  example: "Permission to delete subdivision data denied"
+ *              $ref: "#/components/schemas/Forbidden"
  *      404:
  *        description: Not Found
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Not Found"
- *                details:
- *                  type: string
- *                  example: "Subdivision not found"
+ *              $ref: "#/components/schemas/NotFound"
  */
   .delete(verifyToken, deleteSubdivisionBySubdivisionId)

--- a/src/routes/users-router.ts
+++ b/src/routes/users-router.ts
@@ -6,35 +6,8 @@ import { deleteUserByUsername, getUserByUsername, patchPasswordByUsername, patch
 export const usersRouter = Router()
 
 
-/**
- * @swagger
- * components:
- *  schemas:
- *    User:
- *      type: object
- *      properties:
- *        user_id:
- *          type: integer
- *          example: 1
- *        username:
- *          type: string
- *          example: carrot_king
- *        email:
- *          type: string
- *          example: john.smith@example.com
- *        first_name:
- *          type: string
- *          example: John
- *        surname:
- *          type: string
- *          example: Smith
- *        unit_preference:
- *          type: string
- *          example: imperial
- */
-
-
 usersRouter.route("/users/:username")
+
 
 /**
  * @swagger
@@ -63,27 +36,13 @@ usersRouter.route("/users/:username")
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Forbidden"
- *                details:
- *                  type: string
- *                  example: "Permission to view user data denied"
+ *              $ref: "#/components/schemas/Forbidden"
  *      404:
  *        description: Not Found
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Not Found"
- *                details:
- *                  type: string
- *                  example: "User not found"
+ *              $ref: "#/components/schemas/NotFound"
  */
   .get(verifyToken, getUserByUsername)
 
@@ -133,53 +92,25 @@ usersRouter.route("/users/:username")
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Bad Request"
- *                details:
- *                  type: string
- *                  example: "Invalid text representation"
+ *              $ref: "#/components/schemas/BadRequest"
  *      403:
  *        description: Forbidden
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Forbidden"
- *                details:
- *                  type: string
- *                  example: "Permission to edit user data denied"
+ *              $ref: "#/components/schemas/Forbidden"
  *      404:
  *        description: Not Found
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Not Found"
- *                details:
- *                  type: string
- *                  example: "User not found"
+ *              $ref: "#/components/schemas/NotFound"
  *      409:
  *        description: Conflict
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Conflict"
- *                details:
- *                  type: string
- *                  example: "Email already exists"
+ *              $ref: "#/components/schemas/Conflict"
  */
   .patch(verifyToken, patchUserByUsername)
 
@@ -206,27 +137,13 @@ usersRouter.route("/users/:username")
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Forbidden"
- *                details:
- *                  type: string
- *                  example: "Permission to delete user data denied"
+ *              $ref: "#/components/schemas/Forbidden"
  *      404:
  *        description: Not Found
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Not Found"
- *                details:
- *                  type: string
- *                  example: "User not found"
+ *              $ref: "#/components/schemas/NotFound"
  */
   .delete(verifyToken, deleteUserByUsername)
 
@@ -267,26 +184,12 @@ usersRouter.route("/users/:username")
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Forbidden"
- *                details:
- *                  type: string
- *                  example: "Permission to edit password denied"
+ *              $ref: "#/components/schemas/Forbidden"
  *      404:
  *        description: Not Found
  *        content:
  *          application/json:
  *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: "Not Found"
- *                details:
- *                  type: string
- *                  example: "User not found"
+ *              $ref: "#/components/schemas/NotFound"
  */
 usersRouter.patch("/users/:username/password", verifyToken, patchPasswordByUsername)

--- a/src/swagger/schemas.ts
+++ b/src/swagger/schemas.ts
@@ -1,0 +1,113 @@
+import { Router } from "express"
+
+
+export const schemaRouter = Router()
+
+
+/**
+ * @swagger
+ * components:
+ *  schemas:
+ *    BadRequest:
+ *      type: object
+ *      properties:
+ *        message:
+ *          type: string
+ *          example: "Bad Request"
+ *        details:
+ *          type: string
+ *          example: "Invalid request"
+ *    Conflict:
+ *      type: object
+ *      properties:
+ *        message:
+ *          type: string
+ *          example: "Conflict"
+ *        details:
+ *          type: string
+ *          example: "Content already exists"
+ *    Forbidden:
+ *      type: object
+ *      properties:
+ *        message:
+ *          type: string
+ *          example: "Forbidden"
+ *        details:
+ *          type: string
+ *          example: "Permission denied"
+ *    NotFound:
+ *      type: object
+ *      properties:
+ *        message:
+ *          type: string
+ *          example: "Not Found"
+ *        details:
+ *          type: string
+ *          example: "Result not found"
+ *    Plot:
+ *      type: object
+ *      properties:
+ *        plot_id:
+ *          type: integer
+ *          example: 1
+ *        owner_id:
+ *          type: integer
+ *          example: 1
+ *        name:
+ *          type: string
+ *          example: John's Garden
+ *        type:
+ *          type: string
+ *          example: garden
+ *        description:
+ *          type: string
+ *          example: A vegetable garden
+ *        location:
+ *          type: string
+ *          example: Farmville
+ *        area:
+ *          type: integer
+ *          example: 100
+ *    Subdivision:
+ *      type: object
+ *      properties:
+ *        subdivision_id:
+ *          type: integer
+ *          example: 1
+ *        plot_id:
+ *          type: integer
+ *          example: 1
+ *        name:
+ *          type: string
+ *          example: Root Vegetable Bed
+ *        type:
+ *          type: string
+ *          example: bed
+ *        description:
+ *          type: string
+ *          example: Carrots, beetroots, and parsnips
+ *        area:
+ *          type: integer
+ *          example: 10
+ *    User:
+ *      type: object
+ *      properties:
+ *        user_id:
+ *          type: integer
+ *          example: 1
+ *        username:
+ *          type: string
+ *          example: carrot_king
+ *        email:
+ *          type: string
+ *          example: john.smith@example.com
+ *        first_name:
+ *          type: string
+ *          example: John
+ *        surname:
+ *          type: string
+ *          example: Smith
+ *        unit_preference:
+ *          type: string
+ *          example: imperial
+ */

--- a/src/utils/verification-utils.ts
+++ b/src/utils/verification-utils.ts
@@ -10,13 +10,13 @@ export const verifyPermission = (base: string | number, target: string | number,
 }
 
 
-export const verifyParamIsNumber = (queryParam: number, details: string): Promise<never> | undefined => {
+export const verifyParamIsNumber = (param: number): Promise<never> | undefined => {
 
-  if (isNaN(queryParam)) {
+  if (isNaN(param)) {
     return Promise.reject({
-      status: 404,
-      message: "Not Found",
-      details
+      status: 400,
+      message: "Bad Request",
+      details: "Invalid parameter"
     })
   }
 }


### PR DESCRIPTION
### 404 -> 400

- Modifies `verifyParamIsNumber` to return a 400 status code
- Updates plot and subdivision models and tests to return a 400 status code when a URL parameter that should be a number is not a number (previously 404)

### Swagger

- Added `schemas.ts` to swagger directory with JSDoc annotations for reusable schemas