### PR TITLE
Get crops by plot

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest src/ --runInBand",
     "test-auth": "jest src/__tests__/auth.test.ts",
     "test-login": "jest src/__tests__/login.test.ts",
+    "test-crops": "jest src/__tests__/crops.test.ts",
     "test-plots": "jest src/__tests__/plots.test.ts",
     "test-register": "jest src/__tests__/register.test.ts",
     "test-subdivisions": "jest src/__tests__/subdivisions.test.ts",

--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -212,7 +212,7 @@ describe("GET /api/crops/:plot_id?sort=", () => {
     ])
   })
 
-  test("GET:200 Responds with an array of crop objects sorted by date_planted in descending order while filtering out null values", async () => {
+  test.only("GET:200 Responds with an array of crop objects sorted by date_planted in descending order while filtering out null values", async () => {
 
     const { body } = await request(app)
       .get("/api/crops/1?sort=date_planted")
@@ -220,11 +220,11 @@ describe("GET /api/crops/:plot_id?sort=", () => {
       .expect(200)
 
     expect(body.crops.map((crop: Crop) => {
-      return crop.date_planted
+      return String(crop.date_planted).slice(0, 10)
     })).toEqual([
-      "2024-07-18T23:00:00.000Z",
-      "2024-06-19T23:00:00.000Z",
-      "2023-09-20T23:00:00.000Z",
+      "2024-07-18",
+      "2024-06-19",
+      "2023-09-20",
     ])
   })
 
@@ -236,11 +236,11 @@ describe("GET /api/crops/:plot_id?sort=", () => {
       .expect(200)
 
     expect(body.crops.map((crop: Crop) => {
-      return crop.harvest_date
+      return String(crop.harvest_date).slice(0, 10)
     })).toEqual([
-      "2026-07-18T23:00:00.000Z",
-      "2024-09-20T23:00:00.000Z",
-      "2024-09-14T23:00:00.000Z",
+      "2026-07-18",
+      "2024-09-20",
+      "2024-09-14",
     ])
   })
 
@@ -287,16 +287,16 @@ describe("GET /api/crops/:plot_id?name=&sort=", () => {
     expect(body.crops.map((crop: Crop) => {
       return {
         name: crop.name,
-        harvest_date: crop.harvest_date
+        harvest_date: String(crop.harvest_date).slice(0, 10)
       }
     })).toEqual([
       {
         name: "pecan",
-        harvest_date: "2026-07-18T23:00:00.000Z"
+        harvest_date: "2026-07-18"
       },
       {
         name: "carrot",
-        harvest_date: "2024-09-14T23:00:00.000Z"
+        harvest_date: "2024-09-14"
       }
     ])
   })

--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -146,3 +146,46 @@ describe("GET /api/crops/:plot_id", () => {
     })
   })
 })
+
+
+describe("GET /api/crops/:plot_id?name=", () => {
+
+  test("GET:200 Responds with an array of crop objects filtered by name", async () => {
+
+    const { body } = await request(app)
+      .get("/api/crops/1?name=ca")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+
+    expect(body.crops).toHaveLength(2)
+
+    expect(body.crops.every((crop: Crop) => {
+      return /ca/i.test(crop.name)
+    })).toBe(true)
+  })
+
+  test("GET:200 Filtered results are case-insensitive", async () => {
+
+    const { body } = await request(app)
+      .get("/api/crops/1?name=CA")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+
+    expect(body.crops).toHaveLength(2)
+
+    expect(body.crops.every((crop: Crop) => {
+      return /ca/i.test(crop.name)
+    })).toBe(true)
+  })
+
+  test("GET:200 Returns an empty array when the value of 'name' matches no results", async () => {
+
+    const { body } = await request(app)
+      .get("/api/crops/1?name=example")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+
+    expect(Array.isArray(body.crops)).toBe(true)
+    expect(body.crops).toHaveLength(0)
+  })
+})

--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -25,7 +25,10 @@ beforeEach(async () => {
   token = auth.body.token
 })
 
-afterAll(() => db.end())
+afterAll(() => {
+  seed(data)
+  db.end()
+})
 
 
 describe("GET /api/crops/:plot_id", () => {

--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -212,7 +212,7 @@ describe("GET /api/crops/:plot_id?sort=", () => {
     ])
   })
 
-  test.only("GET:200 Responds with an array of crop objects sorted by date_planted in descending order while filtering out null values", async () => {
+  test("GET:200 Responds with an array of crop objects sorted by date_planted in descending order while filtering out null values", async () => {
 
     const { body } = await request(app)
       .get("/api/crops/1?sort=date_planted")
@@ -220,12 +220,8 @@ describe("GET /api/crops/:plot_id?sort=", () => {
       .expect(200)
 
     expect(body.crops.map((crop: Crop) => {
-      return String(crop.date_planted).slice(0, 10)
-    })).toEqual([
-      "2024-07-18",
-      "2024-06-19",
-      "2023-09-20",
-    ])
+      return crop.crop_id
+    })).toEqual([4, 1, 2])
   })
 
   test("GET:200 Responds with an array of crop objects sorted by harvest_date in descending order while filtering out null values", async () => {
@@ -236,12 +232,8 @@ describe("GET /api/crops/:plot_id?sort=", () => {
       .expect(200)
 
     expect(body.crops.map((crop: Crop) => {
-      return String(crop.harvest_date).slice(0, 10)
-    })).toEqual([
-      "2026-07-18",
-      "2024-09-20",
-      "2024-09-14",
-    ])
+      return crop.crop_id
+    })).toEqual([4, 2, 1])
   })
 
   test("GET:404 Responds with an error when passed an invalid sort value", async () => {
@@ -286,17 +278,14 @@ describe("GET /api/crops/:plot_id?name=&sort=", () => {
 
     expect(body.crops.map((crop: Crop) => {
       return {
-        name: crop.name,
-        harvest_date: String(crop.harvest_date).slice(0, 10)
+        name: crop.name
       }
     })).toEqual([
       {
-        name: "pecan",
-        harvest_date: "2026-07-18"
+        name: "pecan"
       },
       {
-        name: "carrot",
-        harvest_date: "2024-09-14"
+        name: "carrot"
       }
     ])
   })

--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -1,0 +1,145 @@
+import data from "../db/data/test-data/test-index"
+import { db } from "../db"
+import { seed } from "../db/seeding/seed"
+import request from "supertest"
+import { app } from "../app"
+import { Crop } from "../types/crop-types"
+import { toBeOneOf } from 'jest-extended'
+expect.extend({ toBeOneOf })
+
+
+let token: string
+
+
+beforeEach(async () => {
+
+  await seed(data)
+
+  const auth = await request(app)
+    .post("/api/login")
+    .send({
+      username: "carrot_king",
+      password: "carrots123",
+    })
+
+  token = auth.body.token
+})
+
+afterAll(() => db.end())
+
+
+describe("GET /api/crops/:plot_id", () => {
+
+  test("GET:200 Responds with an array of crop objects", async () => {
+
+    const { body } = await request(app)
+      .get("/api/crops/1")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+
+    expect(body.crops).toHaveLength(3)
+
+    const regex = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+
+    body.crops.forEach((crop: Crop) => {
+      expect(crop).toMatchObject({
+        crop_id: expect.any(Number),
+        plot_id: 1,
+        subdivision_id: expect.toBeOneOf([expect.any(Number), null]),
+        name: expect.any(String),
+        variety: expect.toBeOneOf([expect.any(String), null]),
+        quantity: expect.toBeOneOf([expect.any(Number), null]),
+        date_planted: expect.toBeOneOf([expect.stringMatching(regex), null]),
+        harvest_date: expect.toBeOneOf([expect.stringMatching(regex), null]),
+        subdivision_name: expect.toBeOneOf([expect.any(String), null]),
+        note_count: expect.any(Number)
+      })
+    })
+  })
+
+  test("GET:200 Responds with an empty array when no crops are associated with the plot_id", async () => {
+
+    const { body } = await request(app)
+      .get("/api/crops/4")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+
+    expect(Array.isArray(body.crops)).toBe(true)
+    expect(body.crops).toHaveLength(0)
+  })
+
+  test("GET:400 Responds with an error message when the plot_id is not a number", async () => {
+
+    const { body } = await request(app)
+      .get("/api/crops/example")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject({
+      message: "Bad Request",
+      details: "Invalid parameter"
+    })
+  })
+
+  test("GET:403 Responds with a warning when the authenticated user attempts to retrieve another user's crop data", async () => {
+
+    const { body } = await request(app)
+      .get("/api/crops/2")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(403)
+
+    expect(body).toMatchObject({
+      message: "Forbidden",
+      details: "Permission to view crop data denied"
+    })
+  })
+
+  test("GET:404 Responds with an error message when the plot_id does not exist", async () => {
+
+    const { body } = await request(app)
+      .get("/api/crops/999")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(404)
+
+    expect(body).toMatchObject({
+      message: "Not Found",
+      details: "Plot not found"
+    })
+  })
+
+  test("GET:404 When the parent plot is deleted, all child crops are also deleted", async () => {
+
+    await request(app)
+      .delete("/api/plots/plot/1")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(204)
+
+    const { body } = await request(app)
+      .get("/api/crops/1")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(404)
+
+    expect(body).toMatchObject({
+      message: "Not Found",
+      details: "Plot not found"
+    })
+  })
+
+  test("GET:404 When the parent user is deleted, all child crops are also deleted", async () => {
+
+    await request(app)
+      .delete("/api/users/carrot_king")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(204)
+
+    const { body } = await request(app)
+      .get("/api/crops/1")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(404)
+
+    expect(body).toMatchObject({
+      message: "Not Found",
+      details: "Plot not found"
+    })
+  })
+})

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -25,7 +25,10 @@ beforeEach(async () => {
   token = auth.body.token
 })
 
-afterAll(() => db.end())
+afterAll(() => {
+  seed(data)
+  db.end()
+})
 
 
 describe("GET /api/plots/:owner_id", () => {

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -75,7 +75,7 @@ describe("GET /api/plots/:owner_id", () => {
     expect(body.plots).toHaveLength(0)
   })
 
-  test("GET:400 Responds with an error message when the owner_id is not a number", async () => {
+  test("GET:400 Responds with an error message when the owner_id is not a positive integer", async () => {
 
     const { body } = await request(app)
       .get("/api/plots/example")
@@ -303,7 +303,7 @@ describe("POST /api/plots/:owner_id", () => {
     })
   })
 
-  test("POST:400 Responds with an error message when the owner_id is not a number", async () => {
+  test("POST:400 Responds with an error message when the owner_id is not a positive integer", async () => {
 
     const newPlot = {
       owner_id: 1,
@@ -440,7 +440,7 @@ describe("GET /api/plots/plot/:plot_id", () => {
     })
   })
 
-  test("GET:400 Responds with an error message when the plot_id is not a number", async () => {
+  test("GET:400 Responds with an error message when the plot_id is not a positive integer", async () => {
 
     const { body } = await request(app)
       .get("/api/plots/plot/example")
@@ -602,7 +602,7 @@ describe("PATCH /api/plots/plot/:plot_id", () => {
     })
   })
 
-  test("PATCH:400 Responds with an error message when the plot_id is not a number", async () => {
+  test("PATCH:400 Responds with an error message when the plot_id is not a positive integer", async () => {
 
     const newDetails = {
       name: "John's Homestead",
@@ -712,7 +712,7 @@ describe("DELETE /api/plots/plot/:plot_id", () => {
     })
   })
 
-  test("DELETE:400 Responds with an error message when the plot_id is not a number", async () => {
+  test("DELETE:400 Responds with an error message when the plot_id is not a positive integer", async () => {
 
     const { body } = await request(app)
       .delete("/api/plots/plot/example")

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -139,12 +139,14 @@ describe("GET /api/plots/:owner_id?type=", () => {
   test("GET:200 Responds with an array of plot objects filtered by type", async () => {
 
     const { body } = await request(app)
-      .get("/api/plots/1?type=garden")
+      .get("/api/plots/1?type=allotment")
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
+    expect(body.plots).toHaveLength(2)
+
     expect(body.plots.every((plot: Plot) => {
-      return plot.type === "garden"
+      return plot.type === "allotment"
     })).toBe(true)
   })
 

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -25,8 +25,8 @@ beforeEach(async () => {
   token = auth.body.token
 })
 
-afterAll(() => {
-  seed(data)
+afterAll(async () => {
+  await seed(data)
   db.end()
 })
 

--- a/src/__tests__/register.test.ts
+++ b/src/__tests__/register.test.ts
@@ -7,7 +7,10 @@ import { app } from "../app"
 
 beforeEach(() => seed(data))
 
-afterAll(() => db.end())
+afterAll(() => {
+  seed(data)
+  db.end()
+})
 
 
 describe("POST /api/register", () => {

--- a/src/__tests__/register.test.ts
+++ b/src/__tests__/register.test.ts
@@ -7,8 +7,8 @@ import { app } from "../app"
 
 beforeEach(() => seed(data))
 
-afterAll(() => {
-  seed(data)
+afterAll(async () => {
+  await seed(data)
   db.end()
 })
 

--- a/src/__tests__/subdivisions.test.ts
+++ b/src/__tests__/subdivisions.test.ts
@@ -704,7 +704,7 @@ describe("DELETE /api/subdivisions/subdivision/:subdivision_id", () => {
     })
   })
 
-  test("DELETE:403 esponds with a warning when the authenticated user attempts to delete another user's subdivision", async () => {
+  test("DELETE:403 Responds with a warning when the authenticated user attempts to delete another user's subdivision", async () => {
 
     const { body } = await request(app)
       .delete("/api/subdivisions/subdivision/4")

--- a/src/__tests__/subdivisions.test.ts
+++ b/src/__tests__/subdivisions.test.ts
@@ -65,7 +65,7 @@ describe("GET /api/subdivisions/:plot_id", () => {
     expect(body.subdivisions).toHaveLength(0)
   })
 
-  test("GET:400 Responds with an error message when the plot_id is not a number", async () => {
+  test("GET:400 Responds with an error message when the plot_id is not a positive integer", async () => {
 
     const { body } = await request(app)
       .get("/api/subdivisions/example")
@@ -304,7 +304,7 @@ describe("POST /api/subdivisions/:plot_id", () => {
     })
   })
 
-  test("POST:400 Responds with an error message when the plot_id is not a number", async () => {
+  test("POST:400 Responds with an error message when the plot_id is not a positive integer", async () => {
 
     const newSubdivision = {
       plot_id: 1,
@@ -435,7 +435,7 @@ describe("GET /api/subdivisions/subdivision/:subdivision_id", () => {
     })
   })
 
-  test("GET:400 Responds with an error message when the subdivision is not a number", async () => {
+  test("GET:400 Responds with an error message when the subdivision is not a positive integer", async () => {
 
     const { body } = await request(app)
       .get("/api/subdivisions/subdivision/example")
@@ -590,7 +590,7 @@ describe("PATCH /api/subdivisions/subdivision/:subdivision_id", () => {
     })
   })
 
-  test("PATCH:400 Responds with an error message when the subdivision_id is not a number", async () => {
+  test("PATCH:400 Responds with an error message when the subdivision_id is not a positive integer", async () => {
 
     const newDetails = {
       name: "Root Vegetable Patch",
@@ -696,7 +696,7 @@ describe("DELETE /api/subdivisions/subdivision/:subdivision_id", () => {
     })
   })
 
-  test("DELETE:400 Responds with an error message when the subdivision_id is not a number", async () => {
+  test("DELETE:400 Responds with an error message when the subdivision_id is not a positive integer", async () => {
 
     const { body } = await request(app)
       .delete("/api/subdivisions/subdivision/example")

--- a/src/__tests__/subdivisions.test.ts
+++ b/src/__tests__/subdivisions.test.ts
@@ -25,8 +25,8 @@ beforeEach(async () => {
   token = auth.body.token
 })
 
-afterAll(() => {
-  seed(data)
+afterAll(async () => {
+  await seed(data)
   db.end()
 })
 

--- a/src/__tests__/subdivisions.test.ts
+++ b/src/__tests__/subdivisions.test.ts
@@ -151,6 +151,8 @@ describe("GET /api/subdivisions/:plot_id?type=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
+    expect(body.subdivisions).toHaveLength(2)
+
     expect(body.subdivisions.every((subdivision: Subdivision) => {
       return subdivision.type === "bed"
     })).toBe(true)

--- a/src/__tests__/subdivisions.test.ts
+++ b/src/__tests__/subdivisions.test.ts
@@ -25,7 +25,10 @@ beforeEach(async () => {
   token = auth.body.token
 })
 
-afterAll(() => db.end())
+afterAll(() => {
+  seed(data)
+  db.end()
+})
 
 
 describe("GET /api/subdivisions/:plot_id", () => {

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -22,7 +22,10 @@ beforeEach(async () => {
   token = auth.body.token
 })
 
-afterAll(() => db.end())
+afterAll(() => {
+  seed(data)
+  db.end()
+})
 
 
 describe("GET /api/users/:username", () => {

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -22,8 +22,8 @@ beforeEach(async () => {
   token = auth.body.token
 })
 
-afterAll(() => {
-  seed(data)
+afterAll(async () => {
+  await seed(data)
   db.end()
 })
 

--- a/src/__tests__/utils/verification-utils.test.ts
+++ b/src/__tests__/utils/verification-utils.test.ts
@@ -1,4 +1,4 @@
-import { verifyPermission, verifyParamIsPositiveInt } from "../../utils/verification-utils"
+import { verifyPermission, verifyParamIsPositiveInt, verifyPagination } from "../../utils/verification-utils"
 
 
 describe("verifyPermission", () => {
@@ -15,6 +15,24 @@ describe("verifyPermission", () => {
   test("Returns undefined when the base value matches the target value", () => {
 
     expect(verifyPermission(1, 1, "Test")).toBeUndefined()
+  })
+})
+
+
+describe("verifyPagination", () => {
+
+  test("When the page exceeds the possible range, the promise is rejected", () => {
+
+    expect(verifyPagination(3, 5, 10)).rejects.toMatchObject({
+      status: 404,
+      message: "Not Found",
+      details: "Page not found"
+    })
+  })
+
+  test("Returns undefined when the page falls with the possible range", () => {
+
+    expect(verifyPagination(2, 5, 10)).toBeUndefined()
   })
 })
 

--- a/src/__tests__/utils/verification-utils.test.ts
+++ b/src/__tests__/utils/verification-utils.test.ts
@@ -1,4 +1,4 @@
-import { verifyPermission, verifyParamIsNumber } from "../../utils/verification-utils"
+import { verifyPermission, verifyParamIsPositiveInt } from "../../utils/verification-utils"
 
 
 describe("verifyPermission", () => {
@@ -19,11 +19,29 @@ describe("verifyPermission", () => {
 })
 
 
-describe("verifyParamIsNumber", () => {
+describe("verifyParamIsPositiveInt", () => {
 
   test("When the value of the parameter is not a number (NaN), the promise is rejected", () => {
 
-    expect(verifyParamIsNumber(NaN)).rejects.toMatchObject({
+    expect(verifyParamIsPositiveInt(NaN)).rejects.toMatchObject({
+      status: 400,
+      message: "Bad Request",
+      details: "Invalid parameter"
+    })
+  })
+
+  test("When the value of the parameter is a negative number, the promise is rejected", () => {
+
+    expect(verifyParamIsPositiveInt(-1)).rejects.toMatchObject({
+      status: 400,
+      message: "Bad Request",
+      details: "Invalid parameter"
+    })
+  })
+
+  test("When the value of the parameter is not an integer, the promise is rejected", () => {
+
+    expect(verifyParamIsPositiveInt(1.1)).rejects.toMatchObject({
       status: 400,
       message: "Bad Request",
       details: "Invalid parameter"
@@ -32,6 +50,6 @@ describe("verifyParamIsNumber", () => {
 
   test("Returns undefined when the value of the parameter is a number", () => {
 
-    expect(verifyParamIsNumber(1)).toBeUndefined()
+    expect(verifyParamIsPositiveInt(1)).toBeUndefined()
   })
 })

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import { authRouter } from "./routes/auth-router"
 import { usersRouter } from "./routes/users-router"
 import { plotsRouter } from "./routes/plots-router"
 import { subdivisionsRouter } from "./routes/subdivisions-router"
+import { cropsRouter } from "./routes/crops-router"
 
 
 export const app = express()
@@ -38,6 +39,8 @@ app.use("/api", usersRouter)
 app.use("/api", plotsRouter)
 
 app.use("/api", subdivisionsRouter)
+
+app.use("/api", cropsRouter)
 
 
 app.use("/api/docs", swaggerUi.serve, swaggerUi.setup(swaggerSpec))

--- a/src/controllers/crop-controllers.ts
+++ b/src/controllers/crop-controllers.ts
@@ -9,7 +9,7 @@ export const getCropsByPlotId: RequestHandler = async (req, res, next) => {
   const { plot_id } = req.params
 
   try {
-    const crops = await selectCropsByPlotId(authUserId, +plot_id)
+    const crops = await selectCropsByPlotId(authUserId, +plot_id, req.query)
     res.status(200).send({ crops })
   } catch (err) {
     next(err)

--- a/src/controllers/crop-controllers.ts
+++ b/src/controllers/crop-controllers.ts
@@ -1,0 +1,17 @@
+import { RequestHandler } from "express"
+import { selectCropsByPlotId } from "../models/crop-models"
+
+
+export const getCropsByPlotId: RequestHandler = async (req, res, next) => {
+
+  const authUserId: number = req.body.user.user_id
+
+  const { plot_id } = req.params
+
+  try {
+    const crops = await selectCropsByPlotId(authUserId, +plot_id)
+    res.status(200).send({ crops })
+  } catch (err) {
+    next(err)
+  }
+}

--- a/src/controllers/plot-controllers.ts
+++ b/src/controllers/plot-controllers.ts
@@ -8,10 +8,8 @@ export const getPlotsByOwner: RequestHandler = async (req, res, next) => {
 
   const { owner_id } = req.params
 
-  const queries = req.query
-
   try {
-    const plots = await selectPlotsByOwner(authUserId, +owner_id, queries)
+    const plots = await selectPlotsByOwner(authUserId, +owner_id, req.query)
     res.status(200).send({ plots })
   } catch (err) {
     next(err)

--- a/src/controllers/subdivision-controllers.ts
+++ b/src/controllers/subdivision-controllers.ts
@@ -8,10 +8,8 @@ export const getSubdivisionsByPlotId: RequestHandler = async (req, res, next) =>
 
   const { plot_id } = req.params
 
-  const queries = req.query
-
   try {
-    const subdivisions = await selectSubdivisionsByPlotId(authUserId, +plot_id, queries)
+    const subdivisions = await selectSubdivisionsByPlotId(authUserId, +plot_id, req.query)
     res.status(200).send({ subdivisions })
   } catch (err) {
     next(err)

--- a/src/db/data/test-data/crops/crops.ts
+++ b/src/db/data/test-data/crops/crops.ts
@@ -30,6 +30,15 @@ export const cropData: Crop[] = [
     harvest_date: null
   },
   {
+    plot_id: 1,
+    subdivision_id: 1,
+    name: "pecan",
+    variety: null,
+    quantity: 1,
+    date_planted: new Date("2024-07-19"),
+    harvest_date: new Date("2026-07-19")
+  },
+  {
     plot_id: 2,
     subdivision_id: null,
     name: "peach",

--- a/src/db/data/test-data/crops/crops.ts
+++ b/src/db/data/test-data/crops/crops.ts
@@ -21,6 +21,15 @@ export const cropData: Crop[] = [
     harvest_date: new Date("2024-09-21")
   },
   {
+    plot_id: 1,
+    subdivision_id: null,
+    name: "cabbage",
+    variety: null,
+    quantity: null,
+    date_planted:  null,
+    harvest_date: null
+  },
+  {
     plot_id: 2,
     subdivision_id: null,
     name: "peach",

--- a/src/models/crop-models.ts
+++ b/src/models/crop-models.ts
@@ -1,10 +1,12 @@
+import QueryString from "qs"
 import { db } from "../db"
 import { Crop } from "../types/crop-types"
 import { getPlotOwnerId } from "../utils/db-query-utils"
 import { verifyParamIsNumber, verifyPermission } from "../utils/verification-utils"
+import format from "pg-format"
 
 
-export const selectCropsByPlotId = async (authUserId: number, plot_id: number): Promise<Crop[]> => {
+export const selectCropsByPlotId = async (authUserId: number, plot_id: number, { name }: QueryString.ParsedQs): Promise<Crop[]> => {
 
   await verifyParamIsNumber(plot_id)
 
@@ -12,24 +14,28 @@ export const selectCropsByPlotId = async (authUserId: number, plot_id: number): 
 
   await verifyPermission(authUserId, owner_id, "Permission to view crop data denied")
 
-  const result = await db.query(`
-    SELECT
-      crops.*,
-      (
-        SELECT subdivisions.name
-        AS subdivision_name
-        FROM subdivisions
-        WHERE subdivisions.subdivision_id = crops.subdivision_id
-      ),
-      COUNT(crop_notes.crop_id)::INT
-      AS note_count
-    FROM crops
-    LEFT OUTER JOIN crop_notes
-    ON crops.crop_id = crop_notes.crop_id
-    WHERE crops.plot_id = $1
-    GROUP BY crops.crop_id;
-    `,
-    [plot_id])
+  let query = `
+  SELECT
+    crops.*,
+    (
+      SELECT subdivisions.name
+      AS subdivision_name
+      FROM subdivisions
+      WHERE subdivisions.subdivision_id = crops.subdivision_id
+    ),
+    COUNT(crop_notes.crop_id)::INT
+    AS note_count
+  FROM crops
+  LEFT OUTER JOIN crop_notes
+  ON crops.crop_id = crop_notes.crop_id
+  WHERE crops.plot_id = $1
+  `
+
+  if (name) query += format(`AND crops.name ILIKE %L`, `%${name}%`)
+
+  query += `GROUP BY crops.crop_id;`
+
+  const result = await db.query(query, [plot_id])
 
   return result.rows
 }

--- a/src/models/crop-models.ts
+++ b/src/models/crop-models.ts
@@ -1,0 +1,35 @@
+import { db } from "../db"
+import { Crop } from "../types/crop-types"
+import { getPlotOwnerId } from "../utils/db-query-utils"
+import { verifyParamIsNumber, verifyPermission } from "../utils/verification-utils"
+
+
+export const selectCropsByPlotId = async (authUserId: number, plot_id: number): Promise<Crop[]> => {
+
+  await verifyParamIsNumber(plot_id)
+
+  const owner_id = await getPlotOwnerId(plot_id)
+
+  await verifyPermission(authUserId, owner_id, "Permission to view crop data denied")
+
+  const result = await db.query(`
+    SELECT
+      crops.*,
+      (
+        SELECT subdivisions.name
+        AS subdivision_name
+        FROM subdivisions
+        WHERE subdivisions.subdivision_id = crops.subdivision_id
+      ),
+      COUNT(crop_notes.crop_id)::INT
+      AS note_count
+    FROM crops
+    LEFT OUTER JOIN crop_notes
+    ON crops.crop_id = crop_notes.crop_id
+    WHERE crops.plot_id = $1
+    GROUP BY crops.crop_id;
+    `,
+    [plot_id])
+
+  return result.rows
+}

--- a/src/models/plot-models.ts
+++ b/src/models/plot-models.ts
@@ -29,9 +29,11 @@ export const selectPlotsByOwner = async (authUserId: number, owner_id: number, {
     })
   }
 
-  if (type) query += format(`
-    AND type = %L;
-    `, type)
+  if (type) {
+    query += format(`
+      AND type = %L;
+      `, type)
+  }
 
   const result = await db.query(query, [owner_id])
 

--- a/src/models/plot-models.ts
+++ b/src/models/plot-models.ts
@@ -29,7 +29,9 @@ export const selectPlotsByOwner = async (authUserId: number, owner_id: number, {
     })
   }
 
-  if (type) query += format(`AND type = %L;`, type)
+  if (type) query += format(`
+    AND type = %L;
+    `, type)
 
   const result = await db.query(query, [owner_id])
 

--- a/src/models/plot-models.ts
+++ b/src/models/plot-models.ts
@@ -31,11 +31,11 @@ export const selectPlotsByOwner = async (authUserId: number, owner_id: number, {
 
   if (type) {
     query += format(`
-      AND type = %L;
+      AND type = %L
       `, type)
   }
 
-  const result = await db.query(query, [owner_id])
+  const result = await db.query(`${query};`, [owner_id])
 
   return result.rows
 }

--- a/src/models/plot-models.ts
+++ b/src/models/plot-models.ts
@@ -3,12 +3,12 @@ import { db } from "../db"
 import format from "pg-format"
 import { Plot } from "../types/plot-types"
 import { checkPlotNameConflict, getPlotOwnerId, searchForUserId, validatePlotType } from "../utils/db-query-utils"
-import { verifyPermission, verifyParamIsNumber } from "../utils/verification-utils"
+import { verifyPermission, verifyParamIsPositiveInt } from "../utils/verification-utils"
 
 
 export const selectPlotsByOwner = async (authUserId: number, owner_id: number, { type }: QueryString.ParsedQs): Promise<Plot[]> => {
 
-  await verifyParamIsNumber(owner_id)
+  await verifyParamIsPositiveInt(owner_id)
 
   await searchForUserId(owner_id)
 
@@ -43,7 +43,7 @@ export const selectPlotsByOwner = async (authUserId: number, owner_id: number, {
 
 export const insertPlotByOwner = async (authUserId: number, owner_id: number, plot: Plot): Promise<Plot> => {
 
-  await verifyParamIsNumber(owner_id)
+  await verifyParamIsPositiveInt(owner_id)
 
   await searchForUserId(owner_id)
 
@@ -79,7 +79,7 @@ export const insertPlotByOwner = async (authUserId: number, owner_id: number, pl
 
 export const selectPlotByPlotId = async (authUserId: number, plot_id: number): Promise<Plot> => {
 
-  await verifyParamIsNumber(plot_id)
+  await verifyParamIsPositiveInt(plot_id)
 
   const owner_id = await getPlotOwnerId(plot_id)
 
@@ -97,7 +97,7 @@ export const selectPlotByPlotId = async (authUserId: number, plot_id: number): P
 
 export const updatePlotByPlotId = async (authUserId: number, plot_id: number, plot: Plot): Promise<Plot> => {
 
-  await verifyParamIsNumber(plot_id)
+  await verifyParamIsPositiveInt(plot_id)
 
   const owner_id = await getPlotOwnerId(plot_id)
 
@@ -143,7 +143,7 @@ export const updatePlotByPlotId = async (authUserId: number, plot_id: number, pl
 
 export const removePlotByPlotId = async (authUserId: number, plot_id: number): Promise<void> => {
 
-  await verifyParamIsNumber(plot_id)
+  await verifyParamIsPositiveInt(plot_id)
 
   const owner_id = await getPlotOwnerId(plot_id)
 

--- a/src/models/plot-models.ts
+++ b/src/models/plot-models.ts
@@ -59,14 +59,15 @@ export const insertPlotByOwner = async (authUserId: number, owner_id: number, pl
     })
   }
 
-  const result = await db.query(`
+  const result = await db.query(format(`
     INSERT INTO plots
       (owner_id, name, type, description, location, area)
     VALUES
-      ($1, $2, $3, $4, $5, $6)
+      %L
     RETURNING *;
     `,
-    [plot.owner_id, plot.name, plot.type, plot.description, plot.location, plot.area])
+    [[plot.owner_id, plot.name, plot.type, plot.description, plot.location, plot.area]]
+  ))
 
   return result.rows[0]
 }

--- a/src/models/register-models.ts
+++ b/src/models/register-models.ts
@@ -1,3 +1,4 @@
+import format from "pg-format"
 import { db } from "../db"
 import { SecureUser, User } from "../types/user-types"
 import { checkEmailConflict } from "../utils/db-query-utils"
@@ -22,11 +23,11 @@ export const registerUser = async ({ username, password, email, first_name, surn
 
   await checkEmailConflict(email)
 
-  const result = await db.query(`
+  const result = await db.query(format(`
     INSERT INTO users
       (username, password, email, first_name, surname, unit_preference)
     VALUES
-      ($1, $2, $3, $4, $5, $6)
+      %L
     RETURNING 
       user_id, 
       username,
@@ -35,8 +36,8 @@ export const registerUser = async ({ username, password, email, first_name, surn
       surname, 
       unit_preference;
     `,
-    [username, password, email, first_name, surname, unit_preference]
-  )
+    [[username, password, email, first_name, surname, unit_preference]]
+  ))
 
   return result.rows[0]
 }

--- a/src/models/subdivision-models.ts
+++ b/src/models/subdivision-models.ts
@@ -1,14 +1,14 @@
 import QueryString from "qs"
 import { db } from "../db"
 import { checkSubdivisionNameConflict, getPlotOwnerId, getSubdivisionPlotId, validateSubdivisionType } from "../utils/db-query-utils"
-import { verifyPermission, verifyParamIsNumber } from "../utils/verification-utils"
+import { verifyPermission, verifyParamIsPositiveInt } from "../utils/verification-utils"
 import { Subdivision } from "../types/subdivision-types"
 import format from "pg-format"
 
 
 export const selectSubdivisionsByPlotId = async (authUserId: number, plot_id: number, { type }: QueryString.ParsedQs): Promise<Subdivision[]> => {
 
-  await verifyParamIsNumber(plot_id)
+  await verifyParamIsPositiveInt(plot_id)
 
   const owner_id = await getPlotOwnerId(plot_id)
 
@@ -43,7 +43,7 @@ export const selectSubdivisionsByPlotId = async (authUserId: number, plot_id: nu
 
 export const insertSubdivisionByPlotId = async (authUserId: number, plot_id: number, subdivision: Subdivision): Promise<Subdivision> => {
 
-  await verifyParamIsNumber(plot_id)
+  await verifyParamIsPositiveInt(plot_id)
 
   let owner_id = await getPlotOwnerId(plot_id)
 
@@ -81,7 +81,7 @@ export const insertSubdivisionByPlotId = async (authUserId: number, plot_id: num
 
 export const selectSubdivisionBySubdivisionId = async (authUserId: number, subdivision_id: number): Promise<Subdivision> => {
 
-  await verifyParamIsNumber(subdivision_id)
+  await verifyParamIsPositiveInt(subdivision_id)
 
   const plotId = await getSubdivisionPlotId(subdivision_id)
 
@@ -101,7 +101,7 @@ export const selectSubdivisionBySubdivisionId = async (authUserId: number, subdi
 
 export const updateSubdivisionBySubdivisionId = async (authUserId: number, subdivision_id: number, subdivision: Subdivision): Promise<Subdivision> => {
 
-  await verifyParamIsNumber(subdivision_id)
+  await verifyParamIsPositiveInt(subdivision_id)
 
   const plotId = await getSubdivisionPlotId(subdivision_id)
 
@@ -148,7 +148,7 @@ export const updateSubdivisionBySubdivisionId = async (authUserId: number, subdi
 
 export const removeSubdivisionBySubdivisionId = async (authUserId: number, subdivision_id: number): Promise<void> => {
 
-  await verifyParamIsNumber(subdivision_id)
+  await verifyParamIsPositiveInt(subdivision_id)
 
   const plotId = await getSubdivisionPlotId(subdivision_id)
 

--- a/src/models/subdivision-models.ts
+++ b/src/models/subdivision-models.ts
@@ -61,14 +61,15 @@ export const insertSubdivisionByPlotId = async (authUserId: number, plot_id: num
     })
   }
 
-  const result = await db.query(`
+  const result = await db.query(format(`
     INSERT INTO subdivisions
       (plot_id, name, type, description, area)
     VALUES
-      ($1, $2, $3, $4, $5)
+      %L
     RETURNING *;
     `,
-    [subdivision.plot_id, subdivision.name, subdivision.type, subdivision.description, subdivision.area])
+    [[subdivision.plot_id, subdivision.name, subdivision.type, subdivision.description, subdivision.area]]
+  ))
 
   return result.rows[0]
 }

--- a/src/models/subdivision-models.ts
+++ b/src/models/subdivision-models.ts
@@ -29,7 +29,9 @@ export const selectSubdivisionsByPlotId = async (authUserId: number, plot_id: nu
     })
   }
 
-  if (type) query += format(`AND type = %L;`, type)
+  if (type) query += format(`
+    AND type = %L;
+    `, type)
 
   const result = await db.query(query, [plot_id])
 

--- a/src/models/subdivision-models.ts
+++ b/src/models/subdivision-models.ts
@@ -31,11 +31,11 @@ export const selectSubdivisionsByPlotId = async (authUserId: number, plot_id: nu
 
   if (type) {
     query += format(`
-      AND type = %L;
+      AND type = %L
       `, type)
   }
 
-  const result = await db.query(query, [plot_id])
+  const result = await db.query(`${query};`, [plot_id])
 
   return result.rows
 }

--- a/src/models/subdivision-models.ts
+++ b/src/models/subdivision-models.ts
@@ -29,9 +29,11 @@ export const selectSubdivisionsByPlotId = async (authUserId: number, plot_id: nu
     })
   }
 
-  if (type) query += format(`
-    AND type = %L;
-    `, type)
+  if (type) {
+    query += format(`
+      AND type = %L;
+      `, type)
+  }
 
   const result = await db.query(query, [plot_id])
 

--- a/src/routes/crops-router.ts
+++ b/src/routes/crops-router.ts
@@ -28,6 +28,16 @@ cropsRouter.route("/crops/:plot_id")
  *        name: name
  *        schema:
  *          type: string
+ *      - in: query
+ *        name: sort
+ *        schema:
+ *          type: string
+ *        description: crop_id, name, date_planted, harvest_date
+ *      - in: query
+ *        name: order
+ *        schema:
+ *          type: string
+ *        description: asc, desc
  *    responses:
  *      200:
  *        description: OK

--- a/src/routes/crops-router.ts
+++ b/src/routes/crops-router.ts
@@ -16,7 +16,7 @@ cropsRouter.route("/crops/:plot_id")
  *    security:
  *      - bearerAuth: []
  *    summary: Retrieve a plot's crops
- *    description: Responds with an array of crop objects.
+ *    description: Responds with an array of crop objects. If a query parameter is invalid or the plot_id does not exist, the server responds with an error. Permission is denied when the plot does not belong to the current user.
  *    tags: [Crops]
  *    parameters:
  *      - in: path

--- a/src/routes/crops-router.ts
+++ b/src/routes/crops-router.ts
@@ -1,0 +1,80 @@
+import { Router } from "express"
+import { verifyToken } from "../middleware/authentication"
+import { getCropsByPlotId } from "../controllers/crop-controllers"
+
+
+export const cropsRouter = Router()
+
+
+cropsRouter.route("/crops/:plot_id")
+
+
+/**
+ * @swagger
+ * /api/crops/{plot_id}:
+ *  get:
+ *    security:
+ *      - bearerAuth: []
+ *    summary: Retrieve a plot's crops
+ *    description: Responds with an array of crop objects.
+ *    tags: [Crops]
+ *    parameters:
+ *      - in: path
+ *        name: plot_id
+ *        required: true
+ *        schema:
+ *          type: integer
+ *    responses:
+ *      200:
+ *        description: OK
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: array
+ *              items:
+ *                type: object
+ *                properties:
+ *                  crop_id:
+ *                    type: integer
+ *                    example: 1
+ *                  plot_id:
+ *                    type: integer
+ *                    example: 1
+ *                  subdivision_id:
+ *                    type: integer
+ *                    example: 1
+ *                  name:
+ *                    type: string
+ *                    example: carrot
+ *                  variety:
+ *                    type: string
+ *                    example: chantenay
+ *                  quantity:
+ *                    type: integer
+ *                    example: 20
+ *                  date_planted:
+ *                    type: string
+ *                    example: 2024-06-19T23:00:00.000Z
+ *                  harvest_date:
+ *                    type: string
+ *                    example: 2024-09-14T23:00:00.000Z
+ *      400:
+ *        description: Bad Request
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/BadRequest"
+ *      403:
+ *        description: Forbidden
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/Forbidden"
+ *      404:
+ *        description: Not Found
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/NotFound"
+ */
+  .get(verifyToken, getCropsByPlotId)

--- a/src/routes/crops-router.ts
+++ b/src/routes/crops-router.ts
@@ -24,6 +24,10 @@ cropsRouter.route("/crops/:plot_id")
  *        required: true
  *        schema:
  *          type: integer
+ *      - in: query
+ *        name: name
+ *        schema:
+ *          type: string
  *    responses:
  *      200:
  *        description: OK

--- a/src/routes/crops-router.ts
+++ b/src/routes/crops-router.ts
@@ -32,12 +32,22 @@ cropsRouter.route("/crops/:plot_id")
  *        name: sort
  *        schema:
  *          type: string
- *        description: crop_id, name, date_planted, harvest_date
+ *        default: crop_id
  *      - in: query
  *        name: order
  *        schema:
  *          type: string
- *        description: asc, desc
+ *        default: asc
+ *      - in: query
+ *        name: limit
+ *        schema:
+ *          type: integer
+ *        default: 10
+ *      - in: query
+ *        name: page
+ *        schema:
+ *          type: integer
+ *        default: 1
  *    responses:
  *      200:
  *        description: OK

--- a/src/types/crop-types.ts
+++ b/src/types/crop-types.ts
@@ -5,6 +5,6 @@ export type Crop = {
   name: string
   variety: string | null
   quantity: number | null
-  date_planted: Date
-  harvest_date: Date
+  date_planted: Date | null
+  harvest_date: Date | null
 }

--- a/src/utils/verification-utils.ts
+++ b/src/utils/verification-utils.ts
@@ -10,9 +10,9 @@ export const verifyPermission = (base: string | number, target: string | number,
 }
 
 
-export const verifyParamIsNumber = (param: number): Promise<never> | undefined => {
+export const verifyParamIsPositiveInt = (param: number): Promise<never> | undefined => {
 
-  if (isNaN(param)) {
+  if (isNaN(param) || param < 1 || Math.floor(param) !== param) {
     return Promise.reject({
       status: 400,
       message: "Bad Request",

--- a/src/utils/verification-utils.ts
+++ b/src/utils/verification-utils.ts
@@ -1,10 +1,10 @@
-export const verifyPermission = (base: string | number, target: string | number, details: string): Promise<never> | undefined => {
+export const verifyPagination = (page: number, limit: number, count: number): Promise<never> | undefined => {
 
-  if (base !== target) {
+  if (page > 1 && (+limit * +page - +limit) >= count) {
     return Promise.reject({
-      status: 403,
-      message: "Forbidden",
-      details
+      status: 404,
+      message: "Not Found",
+      details: "Page not found"
     })
   }
 }
@@ -17,6 +17,18 @@ export const verifyParamIsPositiveInt = (param: number): Promise<never> | undefi
       status: 400,
       message: "Bad Request",
       details: "Invalid parameter"
+    })
+  }
+}
+
+
+export const verifyPermission = (base: string | number, target: string | number, details: string): Promise<never> | undefined => {
+
+  if (base !== target) {
+    return Promise.reject({
+      status: 403,
+      message: "Forbidden",
+      details
     })
   }
 }


### PR DESCRIPTION
### MVC

- Created new `cropsRouter`
- Imported `cropRouter` into `app.ts`
- Added `getCropsByPlotId` controller
- Added `selectCropsByPlotId` model

### selectCropsByPlotId Model

- Created basic query to return an array of plot objects
- Expanded query to return, if applicable, the name of the subdivision associated with the crop
- Expanded query to return a count of the crop notes associated with the crop
- Expanded query to filter crops by name
- Expanded query to sort crops by name, date planted, or harvest date
- Expanded query to limit and paginate results

### Tests

- Wrote tests for GET /api/crops/:plot_id
- Made `afterAll` async and added call to reseed the test database at the end of suites with tests that mutate the data

### Data

- Added new crop example to test data with null values for date_planted and harvest_date

### Types

- Fixed `Crop` custom type to allow null values for date_planted and harvest_date

### Scripts

- Added `test-crops` script to run `crops.test.ts` individually

### Utils

- Renamed `verifyParamIsNumber` -> `verifyParamIsPositiveInt` to ensure param is an integer greater than 0. Added new tests to check behaviour
- Added `verifyPagination` util and accompanying tests