### PR TITLE
Pagination fixes

### DIFF
--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -64,6 +64,8 @@ describe("GET /api/crops/plot/:plot_id", () => {
         note_count: expect.any(Number)
       })
     }
+
+    expect(body.count).toBe(4)
   })
 
   test("GET:200 Responds with an empty array when no crops are associated with the plot_id", async () => {
@@ -74,7 +76,10 @@ describe("GET /api/crops/plot/:plot_id", () => {
       .expect(200)
 
     expect(Array.isArray(body.crops)).toBe(true)
+
     expect(body.crops).toHaveLength(0)
+
+    expect(body.count).toBe(0)
   })
 
   test("GET:400 Responds with an error message when the plot_id is not a positive integer", async () => {
@@ -166,6 +171,8 @@ describe("GET /api/crops/plot/:plot_id?name=", () => {
     for (const crop of body.crops) {
       expect(crop.name).toMatch(/ca/)
     }
+
+    expect(body.count).toBe(3)
   })
 
   test("GET:200 Filtered results are case-insensitive", async () => {
@@ -178,6 +185,8 @@ describe("GET /api/crops/plot/:plot_id?name=", () => {
     for (const crop of body.crops) {
       expect(crop.name).toMatch(/ca/)
     }
+
+    expect(body.count).toBe(3)
   })
 
   test("GET:200 Returns an empty array when the value of name matches no results", async () => {
@@ -188,7 +197,10 @@ describe("GET /api/crops/plot/:plot_id?name=", () => {
       .expect(200)
 
     expect(Array.isArray(body.crops)).toBe(true)
+
     expect(body.crops).toHaveLength(0)
+
+    expect(body.count).toBe(0)
   })
 })
 
@@ -209,6 +221,8 @@ describe("GET /api/crops/plot/:plot_id?sort=", () => {
     })
 
     expect(body.crops).toEqual(sortedCrops)
+
+    expect(body.count).toBe(4)
   })
 
   test("GET:200 Responds with an array of crop objects sorted by date_planted in descending order while filtering out null values", async () => {
@@ -229,6 +243,8 @@ describe("GET /api/crops/plot/:plot_id?sort=", () => {
     })
 
     expect(body.crops).toEqual(sortedCrops)
+
+    expect(body.count).toBe(3)
   })
 
   test("GET:200 Responds with an array of crop objects sorted by harvest_date in descending order while filtering out null values", async () => {
@@ -249,6 +265,8 @@ describe("GET /api/crops/plot/:plot_id?sort=", () => {
     })
 
     expect(body.crops).toEqual(sortedCrops)
+
+    expect(body.count).toBe(3)
   })
 
   test("GET:404 Responds with an error when passed an invalid sort value", async () => {
@@ -286,6 +304,8 @@ describe("GET /api/crops/plot/:plot_id?name=&sort=", () => {
     })
 
     expect(body.crops).toEqual(sortedCrops)
+
+    expect(body.count).toBe(3)
   })
 
   test("GET:200 Responds with an array of crop objects filtered by name and sorted by harvest_date in descending order while filtering out null values", async () => {
@@ -306,6 +326,8 @@ describe("GET /api/crops/plot/:plot_id?name=&sort=", () => {
     })
 
     expect(body.crops).toEqual(sortedCrops)
+
+    expect(body.count).toBe(2)
   })
 })
 
@@ -337,6 +359,8 @@ describe("GET /api/crops/plot/:plot_id?name=&limit=", () => {
       .expect(200)
 
     expect(body.crops).toHaveLength(2)
+
+    expect(body.count).toBe(4)
   })
 
   test("GET:200 Responds with an array of all crops associated with the plot when the limit exceeds the total number of results", async () => {
@@ -347,6 +371,8 @@ describe("GET /api/crops/plot/:plot_id?name=&limit=", () => {
       .expect(200)
 
     expect(body.crops).toHaveLength(4)
+
+    expect(body.count).toBe(4)
   })
 
   test("GET:400 Responds with an error message when the value of limit is not a positive integer", async () => {
@@ -376,6 +402,8 @@ describe("GET /api/crops/plot/:plot_id?name=&page=", () => {
     expect(body.crops.map((crop: Crop) => {
       return crop.crop_id
     })).toEqual([3, 4])
+
+    expect(body.count).toBe(4)
   })
 
   test("GET:200 The page defaults to page one", async () => {
@@ -388,6 +416,8 @@ describe("GET /api/crops/plot/:plot_id?name=&page=", () => {
     expect(body.crops.map((crop: Crop) => {
       return crop.crop_id
     })).toEqual([1, 2])
+
+    expect(body.count).toBe(4)
   })
 
   test("GET:200 When there are fewer results on the final page, the response contains those results", async () => {
@@ -400,12 +430,27 @@ describe("GET /api/crops/plot/:plot_id?name=&page=", () => {
     expect(body.crops.map((crop: Crop) => {
       return crop.crop_id
     })).toEqual([4])
+
+    expect(body.count).toBe(4)
   })
 
-  test("GET:404 Responds with an error when the value of page exceeds the page limit", async () => {
+  test("GET:404 Responds with an error when the page cannot be found", async () => {
 
     const { body } = await request(app)
       .get("/api/crops/plot/1?limit=2&page=3")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(404)
+
+    expect(body).toMatchObject({
+      message: "Not Found",
+      details: "Page not found"
+    })
+  })
+
+  test("GET:404 Responds with an error when the page cannot be found", async () => {
+
+    const { body } = await request(app)
+      .get("/api/crops/plot/1?name=ca&sort=harvest_date&limit=2&page=2")
       .set("Authorization", `Bearer ${token}`)
       .expect(404)
 

--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -447,7 +447,7 @@ describe("GET /api/crops/plot/:plot_id?name=&page=", () => {
     })
   })
 
-  test("GET:404 Responds with an error when the page cannot be found", async () => {
+  test("GET:404 Responds with an error when the page cannot be found (multiple queries affecting total query result rows)", async () => {
 
     const { body } = await request(app)
       .get("/api/crops/plot/1?name=ca&sort=harvest_date&limit=2&page=2")

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -71,6 +71,7 @@ describe("GET /api/plots/user/:owner_id", () => {
       .expect(200)
 
     expect(Array.isArray(body.plots)).toBe(true)
+
     expect(body.plots).toHaveLength(0)
   })
 

--- a/src/__tests__/subdivisions.test.ts
+++ b/src/__tests__/subdivisions.test.ts
@@ -61,6 +61,7 @@ describe("GET /api/subdivisions/plot/:plot_id", () => {
       .expect(200)
 
     expect(Array.isArray(body.subdivisions)).toBe(true)
+
     expect(body.subdivisions).toHaveLength(0)
   })
 

--- a/src/__tests__/utils/verification-utils.test.ts
+++ b/src/__tests__/utils/verification-utils.test.ts
@@ -21,18 +21,23 @@ describe("verifyPermission", () => {
 
 describe("verifyPagination", () => {
 
-  test("When the page exceeds the possible range, the promise is rejected", () => {
+  test("When the page number is greater than one and the query result returns no rows, the promise is rejects", () => {
 
-    expect(verifyPagination(3, 5, 10)).rejects.toMatchObject({
+    expect(verifyPagination(2, 0)).rejects.toMatchObject({
       status: 404,
       message: "Not Found",
       details: "Page not found"
     })
   })
 
-  test("Returns undefined when the page falls with the possible range", () => {
+  test("Returns undefined when the page number is one", () => {
 
-    expect(verifyPagination(2, 5, 10)).toBeUndefined()
+    expect(verifyPagination(1, 0)).toBeUndefined()
+  })
+
+  test("Returns undefined when the query result returns at least one row", () => {
+
+    expect(verifyPagination(2, 1)).toBeUndefined()
   })
 })
 

--- a/src/controllers/crop-controllers.ts
+++ b/src/controllers/crop-controllers.ts
@@ -9,8 +9,8 @@ export const getCropsByPlotId: RequestHandler = async (req, res, next) => {
   const { plot_id } = req.params
 
   try {
-    const crops = await selectCropsByPlotId(authUserId, +plot_id, req.query)
-    res.status(200).send({ crops })
+    const [crops, count] = await selectCropsByPlotId(authUserId, +plot_id, req.query)
+    res.status(200).send({ crops, count })
   } catch (err) {
     next(err)
   }

--- a/src/utils/verification-utils.ts
+++ b/src/utils/verification-utils.ts
@@ -1,6 +1,6 @@
-export const verifyPagination = (page: number, limit: number, count: number): Promise<never> | undefined => {
+export const verifyPagination = (page: number, queryResultRowsLength: number): Promise<never> | undefined => {
 
-  if (page > 1 && (limit * page - limit) >= count) {
+  if (page > 1 && !queryResultRowsLength) {
     return Promise.reject({
       status: 404,
       message: "Not Found",


### PR DESCRIPTION
### Summary

- Updated `selectCropsById` to build a `countQuery` to return the total number of results before limit and pagination are applied
- The resulting count is returned inside a `Promise.all` array along with the main query result
- Updated `getCropsByPlotId` to destructure the results from `selectCropByPlotId` and send both `crops` and `count` on the response body
- Modified parameters of `verifyPagination` and accompanying tests
- Updated `crops.test.ts` test suite to test the `count` object on the response body. Added a new test for pagination