### PR TITLE
Auth fixes

### DIFF
--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -53,7 +53,7 @@ describe("GET /api/auth", () => {
 
     expect(body).toMatchObject({
       message: "Unauthorized",
-      details: "Token could not be verified"
+      details: "Invalid or expired token"
     })
   })
 })

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -32,7 +32,7 @@ describe("GET /api/auth", () => {
     })
   })
 
-  test("GET:401 Responds with an authorisation warning when valid credentials have not been provided", async () => {
+  test("GET:401 Responds with a warning when valid credentials have not been provided", async () => {
 
     const { body } = await request(app)
       .get("/api/auth")
@@ -40,19 +40,19 @@ describe("GET /api/auth", () => {
 
     expect(body).toMatchObject({
       message: "Unauthorized",
-      details: "Invalid credentials provided"
+      details: "Login required"
     })
   })
 
-  test("GET:403 Responds with a warning when the token cannot be verified", async () => {
+  test("GET:401 Responds with a warning when the token cannot be verified", async () => {
 
     const { body } = await request(app)
       .get("/api/auth")
       .set("Authorization", `Bearer invalidToken`)
-      .expect(403)
+      .expect(401)
 
     expect(body).toMatchObject({
-      message: "Forbidden",
+      message: "Unauthorized",
       details: "Token could not be verified"
     })
   })

--- a/src/controllers/crop-controllers.ts
+++ b/src/controllers/crop-controllers.ts
@@ -1,10 +1,11 @@
-import { RequestHandler } from "express"
+import { NextFunction, Response } from "express"
 import { insertCropByPlotId, selectCropsByPlotId } from "../models/crop-models"
+import { ExtendedRequest } from "../types/auth-types"
 
 
-export const getCropsByPlotId: RequestHandler = async (req, res, next) => {
+export const getCropsByPlotId = async (req: ExtendedRequest, res: Response, next: NextFunction) => {
 
-  const authUserId: number = req.body.user.user_id
+  const authUserId: number = req.user!.user_id
 
   const { plot_id } = req.params
 
@@ -17,9 +18,9 @@ export const getCropsByPlotId: RequestHandler = async (req, res, next) => {
 }
 
 
-export const postCropByPlotId: RequestHandler = async (req, res, next) => {
+export const postCropByPlotId = async (req: ExtendedRequest, res: Response, next: NextFunction) => {
 
-  const authUserId: number = req.body.user.user_id
+  const authUserId: number = req.user!.user_id
 
   const { plot_id } = req.params
 

--- a/src/controllers/plot-controllers.ts
+++ b/src/controllers/plot-controllers.ts
@@ -1,10 +1,11 @@
-import { RequestHandler } from "express"
+import { NextFunction, Response } from "express"
 import { insertPlotByOwner, removePlotByPlotId, selectPlotByPlotId, selectPlotsByOwner, updatePlotByPlotId } from "../models/plot-models"
+import { ExtendedRequest } from "../types/auth-types"
 
 
-export const getPlotsByOwner: RequestHandler = async (req, res, next) => {
+export const getPlotsByOwner = async (req: ExtendedRequest, res: Response, next: NextFunction) => {
 
-  const authUserId: number = req.body.user.user_id
+  const authUserId: number = req.user!.user_id
 
   const { owner_id } = req.params
 
@@ -17,9 +18,9 @@ export const getPlotsByOwner: RequestHandler = async (req, res, next) => {
 }
 
 
-export const postPlotByOwner: RequestHandler = async (req, res, next) => {
+export const postPlotByOwner= async (req: ExtendedRequest, res: Response, next: NextFunction) => {
 
-  const authUserId: number = req.body.user.user_id
+  const authUserId: number = req.user!.user_id
 
   const { owner_id } = req.params
 
@@ -32,9 +33,9 @@ export const postPlotByOwner: RequestHandler = async (req, res, next) => {
 }
 
 
-export const getPlotByPlotId: RequestHandler = async (req, res, next) => {
+export const getPlotByPlotId= async (req: ExtendedRequest, res: Response, next: NextFunction) => {
 
-  const authUserId: number = req.body.user.user_id
+  const authUserId: number = req.user!.user_id
 
   const { plot_id } = req.params
 
@@ -47,9 +48,9 @@ export const getPlotByPlotId: RequestHandler = async (req, res, next) => {
 }
 
 
-export const patchPlotByPlotId: RequestHandler = async (req, res, next) => {
+export const patchPlotByPlotId= async (req: ExtendedRequest, res: Response, next: NextFunction) => {
 
-  const authUserId: number = req.body.user.user_id
+  const authUserId: number = req.user!.user_id
 
   const { plot_id } = req.params
 
@@ -62,9 +63,9 @@ export const patchPlotByPlotId: RequestHandler = async (req, res, next) => {
 }
 
 
-export const deletePlotByPlotId: RequestHandler = async (req, res, next) => {
+export const deletePlotByPlotId= async (req: ExtendedRequest, res: Response, next: NextFunction) => {
 
-  const authUserId: number = req.body.user.user_id
+  const authUserId: number = req.user!.user_id
 
   const { plot_id } = req.params
 

--- a/src/controllers/subdivision-controllers.ts
+++ b/src/controllers/subdivision-controllers.ts
@@ -1,10 +1,11 @@
-import { RequestHandler } from "express"
+import { NextFunction, Response } from "express"
 import { insertSubdivisionByPlotId, removeSubdivisionBySubdivisionId, selectSubdivisionBySubdivisionId, selectSubdivisionsByPlotId, updateSubdivisionBySubdivisionId } from "../models/subdivision-models"
+import { ExtendedRequest } from "../types/auth-types"
 
 
-export const getSubdivisionsByPlotId: RequestHandler = async (req, res, next) => {
+export const getSubdivisionsByPlotId = async (req: ExtendedRequest, res: Response, next: NextFunction) => {
 
-  const authUserId: number = req.body.user.user_id
+  const authUserId: number = req.user!.user_id
 
   const { plot_id } = req.params
 
@@ -17,9 +18,9 @@ export const getSubdivisionsByPlotId: RequestHandler = async (req, res, next) =>
 }
 
 
-export const postSubdivisionByPlotId: RequestHandler = async (req, res, next) => {
+export const postSubdivisionByPlotId = async (req: ExtendedRequest, res: Response, next: NextFunction) => {
 
-  const authUserId: number = req.body.user.user_id
+  const authUserId: number = req.user!.user_id
 
   const { plot_id } = req.params
 
@@ -32,9 +33,9 @@ export const postSubdivisionByPlotId: RequestHandler = async (req, res, next) =>
 }
 
 
-export const getSubdivisionBySubdivisionId: RequestHandler = async (req, res, next) => {
+export const getSubdivisionBySubdivisionId = async (req: ExtendedRequest, res: Response, next: NextFunction) => {
 
-  const authUserId: number = req.body.user.user_id
+  const authUserId: number = req.user!.user_id
 
   const { subdivision_id } = req.params
 
@@ -47,9 +48,9 @@ export const getSubdivisionBySubdivisionId: RequestHandler = async (req, res, ne
 }
 
 
-export const patchSubdivisionBySubdivisionId: RequestHandler = async (req, res, next) => {
+export const patchSubdivisionBySubdivisionId = async (req: ExtendedRequest, res: Response, next: NextFunction) => {
 
-  const authUserId: number = req.body.user.user_id
+  const authUserId: number = req.user!.user_id
 
   const { subdivision_id } = req.params
 
@@ -62,9 +63,9 @@ export const patchSubdivisionBySubdivisionId: RequestHandler = async (req, res, 
 }
 
 
-export const deleteSubdivisionBySubdivisionId: RequestHandler = async (req, res, next) => {
+export const deleteSubdivisionBySubdivisionId = async (req: ExtendedRequest, res: Response, next: NextFunction) => {
 
-  const authUserId: number = req.body.user.user_id
+  const authUserId: number = req.user!.user_id
 
   const { subdivision_id } = req.params
 

--- a/src/controllers/user-controllers.ts
+++ b/src/controllers/user-controllers.ts
@@ -1,10 +1,11 @@
-import { RequestHandler } from "express"
+import { NextFunction, Response } from "express"
 import { changePasswordByUsername, removeUserByUsername, selectUserByUsername, updateUserByUsername } from "../models/user-models"
+import { ExtendedRequest } from "../types/auth-types"
 
 
-export const getUserByUsername: RequestHandler = async (req, res, next) => {
+export const getUserByUsername = async (req: ExtendedRequest, res: Response, next: NextFunction) => {
 
-  const authUsername: string = req.body.user.username
+  const authUsername: string = req.user!.username
 
   const { username } = req.params
 
@@ -17,9 +18,9 @@ export const getUserByUsername: RequestHandler = async (req, res, next) => {
 }
 
 
-export const patchUserByUsername: RequestHandler = async (req, res, next) => {
+export const patchUserByUsername = async (req: ExtendedRequest, res: Response, next: NextFunction) => {
 
-  const authUsername: string = req.body.user.username
+  const authUsername: string = req.user!.username
 
   const { username } = req.params
 
@@ -32,9 +33,9 @@ export const patchUserByUsername: RequestHandler = async (req, res, next) => {
 }
 
 
-export const deleteUserByUsername: RequestHandler = async (req, res, next) => {
+export const deleteUserByUsername = async (req: ExtendedRequest, res: Response, next: NextFunction) => {
 
-  const authUsername = req.body.user.username
+  const authUsername = req.user!.username
 
   const { username } = req.params
 
@@ -47,9 +48,9 @@ export const deleteUserByUsername: RequestHandler = async (req, res, next) => {
 }
 
 
-export const patchPasswordByUsername: RequestHandler = async (req, res, next) => {
+export const patchPasswordByUsername = async (req: ExtendedRequest, res: Response, next: NextFunction) => {
 
-  const authUsername: string = req.body.user.username
+  const authUsername: string = req.user!.username
 
   const { username } = req.params
 

--- a/src/middleware/authentication.ts
+++ b/src/middleware/authentication.ts
@@ -28,7 +28,7 @@ export const verifyToken = (req: ExtendedRequest, res: Response, next: NextFunct
     if (err) {
       return res.status(401).send({
         message: "Unauthorized",
-        details: "Token could not be verified"
+        details: "Invalid or expired token"
       })
     }
 

--- a/src/middleware/authentication.ts
+++ b/src/middleware/authentication.ts
@@ -1,6 +1,7 @@
-import { RequestHandler } from "express"
+import { NextFunction, Response } from "express"
 import jwt from "jsonwebtoken"
 import { LoggedInUser } from "../types/user-types"
+import { ExtendedRequest } from "../types/auth-types"
 
 
 export const generateToken = (user: LoggedInUser): string => {
@@ -9,7 +10,7 @@ export const generateToken = (user: LoggedInUser): string => {
 }
 
 
-export const verifyToken: RequestHandler = (req, res, next) => {
+export const verifyToken = (req: ExtendedRequest, res: Response, next: NextFunction) => {
 
   const bearer = req.headers.authorization
 
@@ -31,7 +32,7 @@ export const verifyToken: RequestHandler = (req, res, next) => {
       })
     }
 
-    req.body.user = user
+    req.user = user
 
     next()
   })

--- a/src/middleware/authentication.ts
+++ b/src/middleware/authentication.ts
@@ -18,15 +18,15 @@ export const verifyToken: RequestHandler = (req, res, next) => {
   if (!token) {
     return res.status(401).send({
       message: "Unauthorized",
-      details: "Invalid credentials provided"
+      details: "Login required"
     })
   }
 
   jwt.verify(token!, process.env.JWT_SECRET!, (err: any, user: any) => {
 
     if (err) {
-      return res.status(403).send({
-        message: "Forbidden",
+      return res.status(401).send({
+        message: "Unauthorized",
         details: "Token could not be verified"
       })
     }

--- a/src/routes/auth-router.ts
+++ b/src/routes/auth-router.ts
@@ -41,13 +41,13 @@ export const authRouter = Router()
  *                details:
  *                  type: string
  *            examples:
- *              Login status:
+ *              Login required:
  *                value:
  *                  message: Unauthorized
  *                  details: Login required
- *              Invalid token:
+ *              Invalid or expired token:
  *                value:
  *                  message: Unauthorized
- *                  details: Token could not be verified
+ *                  details: Invalid or expired token
  */
 authRouter.get("/auth", verifyToken, testAuth)

--- a/src/routes/auth-router.ts
+++ b/src/routes/auth-router.ts
@@ -38,22 +38,16 @@ export const authRouter = Router()
  *              properties:
  *                message:
  *                  type: string
- *                  example: Unauthorized
  *                details:
  *                  type: string
- *                  example: Invalid credentials provided
- *      403:
- *        description: Forbidden
- *        content:
- *          application/json:
- *            schema:
- *              type: object
- *              properties:
- *                message:
- *                  type: string
- *                  example: Forbidden
- *                details:
- *                  type: string
- *                  example: Token could not be verified
+ *            examples:
+ *              Login status:
+ *                value:
+ *                  message: Unauthorized
+ *                  details: Login required
+ *              Invalid token:
+ *                value:
+ *                  message: Unauthorized
+ *                  details: Token could not be verified
  */
 authRouter.get("/auth", verifyToken, testAuth)

--- a/src/types/auth-types.ts
+++ b/src/types/auth-types.ts
@@ -1,0 +1,14 @@
+import { Request } from "express"
+
+
+export type AuthUser = {
+  user?: {
+    user_id: number
+    username: string
+    iat: number
+    exp: number
+  }
+}
+
+
+export type ExtendedRequest = AuthUser & Request


### PR DESCRIPTION
### Fixes

- Changed 403 error to 401 error when token cannot be verified in `verifyToken`
- Updated auth tests and auth router JSDoc annotations
- Created `AuthUser` and `ExtendedRequest` types in `auth-types.ts` to allow the `user` property to be added to an Express request object
- Replaced `req.body.user` with `req.user` to send the `user` property separately from the body on the request object
- Updated `verifyToken` and all controllers that need access to `req.user` to use the new `ExtendedRequest` type