### PR TITLE
Post crop by subdivision

### DIFF
--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -464,11 +464,9 @@ describe("GET /api/crops/plot/:plot_id?name=&page=", () => {
 
 describe("POST /api/crops/plot/:plot_id", () => {
 
-  test("POST:201 Responds with a new crop object", async () => {
+  test("POST:201 Responds with a new crop object, assigning plot_id and subdivision_id (null) automatically", async () => {
 
     const newCrop = {
-      plot_id: 1,
-      subdivision_id: null,
       name: "pear",
       variety: "conference",
       quantity: 1,
@@ -497,7 +495,6 @@ describe("POST /api/crops/plot/:plot_id", () => {
   test("POST:201 Assigns a null value to 'subdivision_id', 'variety', 'quantity', 'date_planted', and 'harvest_date' when no value is provided", async () => {
 
     const newCrop = {
-      plot_id: 1,
       name: "pear"
     }
 
@@ -522,7 +519,6 @@ describe("POST /api/crops/plot/:plot_id", () => {
   test("POST:201 Ignores any unnecessary properties on the object", async () => {
 
     const newCrop = {
-      plot_id: 1,
       name: "pear",
       price: 100
     }
@@ -539,7 +535,6 @@ describe("POST /api/crops/plot/:plot_id", () => {
   test("POST:400 Responds with an error when passed a property with an invalid data type", async () => {
 
     const newCrop = {
-      plot_id: 1,
       name: "pear",
       quantity: "one",
     }
@@ -558,9 +553,7 @@ describe("POST /api/crops/plot/:plot_id", () => {
 
   test("POST:400 Responds with an error when a required property is missing from the request body", async () => {
 
-    const newCrop = {
-      plot_id: 1
-    }
+    const newCrop = {}
 
     const { body } = await request(app)
       .post("/api/crops/plot/1")
@@ -577,7 +570,6 @@ describe("POST /api/crops/plot/:plot_id", () => {
   test("POST:400 Responds with an error message when the plot_id is not a positive integer", async () => {
 
     const newCrop = {
-      plot_id: 1,
       name: "pear"
     }
 
@@ -596,7 +588,6 @@ describe("POST /api/crops/plot/:plot_id", () => {
   test("POST:403 Responds with a warning when the authenticated user attempts to add a crop for another user", async () => {
 
     const newCrop = {
-      plot_id: 1,
       name: "pear"
     }
 
@@ -612,29 +603,9 @@ describe("POST /api/crops/plot/:plot_id", () => {
     })
   })
 
-  test("POST:403 Responds with a warning when the authenticated user attempts to add a crop for another user (forbidden plot_id on request body)", async () => {
-
-    const newCrop = {
-      plot_id: 2,
-      name: "pear"
-    }
-
-    const { body } = await request(app)
-      .post("/api/crops/plot/1")
-      .send(newCrop)
-      .set("Authorization", `Bearer ${token}`)
-      .expect(403)
-
-    expect(body).toMatchObject({
-      message: "Forbidden",
-      details: "Permission to add crop denied"
-    })
-  })
-
   test("POST:404 Responds with an error message when the plot_id does not exist", async () => {
 
     const newCrop = {
-      plot_id: 1,
       name: "pear"
     }
 
@@ -1043,6 +1014,167 @@ describe("GET /api/crops/subdivision/:subdivision_id?name=&page=", () => {
     expect(body).toMatchObject({
       message: "Not Found",
       details: "Page not found"
+    })
+  })
+})
+
+
+describe("POST /api/crops/subdivision/:subdivision_id", () => {
+
+  test("POST:201 Responds with a new crop object, assigning plot_id and subdivision_id automatically", async () => {
+
+    const newCrop = {
+      name: "pear",
+      variety: "conference",
+      quantity: 1,
+      date_planted: new Date("2024-07-21"),
+      harvest_date: new Date("2024-09-30")
+    }
+
+    const { body } = await request(app)
+      .post("/api/crops/subdivision/1")
+      .send(newCrop)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(201)
+
+    expect(body.crop).toMatchObject({
+      crop_id: 7,
+      plot_id: 1,
+      subdivision_id: 1,
+      name: "pear",
+      variety: "conference",
+      quantity: 1,
+      date_planted: expect.toBeOneOf([expect.stringMatching(regex), null]),
+      harvest_date: expect.toBeOneOf([expect.stringMatching(regex), null])
+    })
+  })
+
+  test("POST:201 Assigns a null value to 'variety', 'quantity', 'date_planted', and 'harvest_date' when no value is provided", async () => {
+
+    const newCrop = {
+      name: "pear"
+    }
+
+    const { body } = await request(app)
+      .post("/api/crops/subdivision/1")
+      .send(newCrop)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(201)
+
+    expect(body.crop).toMatchObject({
+      crop_id: 7,
+      plot_id: 1,
+      subdivision_id: 1,
+      name: "pear",
+      variety: null,
+      quantity: null,
+      date_planted: null,
+      harvest_date: null
+    })
+  })
+
+  test("POST:201 Ignores any unnecessary properties on the object", async () => {
+
+    const newCrop = {
+      name: "pear",
+      price: 100
+    }
+
+    const { body } = await request(app)
+      .post("/api/crops/subdivision/1")
+      .send(newCrop)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(201)
+
+    expect(body.crop).not.toHaveProperty("price")
+  })
+
+  test("POST:400 Responds with an error when passed a property with an invalid data type", async () => {
+
+    const newCrop = {
+      name: "pear",
+      quantity: "one",
+    }
+
+    const { body } = await request(app)
+      .post("/api/crops/subdivision/1")
+      .send(newCrop)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject({
+      message: "Bad Request",
+      details: "Invalid text representation"
+    })
+  })
+
+  test("POST:400 Responds with an error when a required property is missing from the request body", async () => {
+
+    const newCrop = {}
+
+    const { body } = await request(app)
+      .post("/api/crops/subdivision/1")
+      .send(newCrop)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject({
+      message: "Bad Request",
+      details: "Not null violation"
+    })
+  })
+
+  test("POST:400 Responds with an error message when the plot_id is not a positive integer", async () => {
+
+    const newCrop = {
+      name: "pear"
+    }
+
+    const { body } = await request(app)
+      .post("/api/crops/subdivision/example")
+      .send(newCrop)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject({
+      message: "Bad Request",
+      details: "Invalid parameter"
+    })
+  })
+
+  test("POST:403 Responds with a warning when the authenticated user attempts to add a crop for another user", async () => {
+
+    const newCrop = {
+      name: "pear"
+    }
+
+    const { body } = await request(app)
+      .post("/api/crops/subdivision/4")
+      .send(newCrop)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(403)
+
+    expect(body).toMatchObject({
+      message: "Forbidden",
+      details: "Permission to add crop denied"
+    })
+  })
+
+  test("POST:404 Responds with an error message when the plot_id does not exist", async () => {
+
+    const newCrop = {
+      name: "pear"
+    }
+
+    const { body } = await request(app)
+      .post("/api/crops/plot/999")
+      .send(newCrop)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(404)
+
+    expect(body).toMatchObject({
+      message: "Not Found",
+      details: "Plot not found"
     })
   })
 })

--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -1160,21 +1160,21 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
     })
   })
 
-  test("POST:404 Responds with an error message when the plot_id does not exist", async () => {
+  test("POST:404 Responds with an error message when the subdivision does not exist", async () => {
 
     const newCrop = {
       name: "pear"
     }
 
     const { body } = await request(app)
-      .post("/api/crops/plot/999")
+      .post("/api/crops/subdivision/999")
       .send(newCrop)
       .set("Authorization", `Bearer ${token}`)
       .expect(404)
 
     expect(body).toMatchObject({
       message: "Not Found",
-      details: "Plot not found"
+      details: "Subdivision not found"
     })
   })
 })

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -167,7 +167,7 @@ describe("GET /api/plots/user/:owner_id?type=", () => {
 
 describe("POST /api/plots/user/:owner_id", () => {
 
-  test("POST:201 Responds with a new plot object, assigning plot_id automatically", async () => {
+  test("POST:201 Responds with a new plot object, assigning owner_id automatically", async () => {
 
     const newPlot = {
       name: "John's Field",

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -167,10 +167,9 @@ describe("GET /api/plots/user/:owner_id?type=", () => {
 
 describe("POST /api/plots/user/:owner_id", () => {
 
-  test("POST:201 Responds with a new plot object", async () => {
+  test("POST:201 Responds with a new plot object, assigning plot_id automatically", async () => {
 
     const newPlot = {
-      owner_id: 1,
       name: "John's Field",
       type: "field",
       description: "A large field",
@@ -198,7 +197,6 @@ describe("POST /api/plots/user/:owner_id", () => {
   test("POST:201 Assigns a null value to 'area' when no value is provided", async () => {
 
     const newPlot = {
-      owner_id: 1,
       name: "John's Field",
       type: "field",
       description: "A large field",
@@ -217,7 +215,6 @@ describe("POST /api/plots/user/:owner_id", () => {
   test("POST:201 Ignores any unnecessary properties on the object", async () => {
 
     const newPlot = {
-      owner_id: 1,
       name: "John's Field",
       type: "field",
       description: "A large field",
@@ -238,7 +235,6 @@ describe("POST /api/plots/user/:owner_id", () => {
   test("POST:400 Responds with an error when passed a property with an invalid data type", async () => {
 
     const newPlot = {
-      owner_id: 1,
       name: "John's Field",
       type: "field",
       description: "A large field",
@@ -261,7 +257,6 @@ describe("POST /api/plots/user/:owner_id", () => {
   test("POST:400 Responds with an error when a required property is missing from the request body", async () => {
 
     const newPlot = {
-      owner_id: 1,
       type: "field",
       description: "A large field",
       location: "Wildwood",
@@ -283,7 +278,6 @@ describe("POST /api/plots/user/:owner_id", () => {
   test("POST:400 Responds with an error when passed an invalid plot type", async () => {
 
     const newPlot = {
-      owner_id: 1,
       name: "John's Field",
       type: "garage",
       description: "A large field",
@@ -306,7 +300,6 @@ describe("POST /api/plots/user/:owner_id", () => {
   test("POST:400 Responds with an error message when the owner_id is not a positive integer", async () => {
 
     const newPlot = {
-      owner_id: 1,
       name: "John's Field",
       type: "field",
       description: "A large field",
@@ -329,7 +322,6 @@ describe("POST /api/plots/user/:owner_id", () => {
   test("POST:403 Responds with a warning when the authenticated user attempts to create a plot for another user", async () => {
 
     const newPlot = {
-      owner_id: 1,
       name: "John's Field",
       type: "field",
       description: "A large field",
@@ -349,33 +341,9 @@ describe("POST /api/plots/user/:owner_id", () => {
     })
   })
 
-  test("POST:403 Responds with a warning when the authenticated user attempts to create a plot for another user (forbidden owner_id on request body)", async () => {
-
-    const newPlot = {
-      owner_id: 2,
-      name: "John's Field",
-      type: "field",
-      description: "A large field",
-      location: "Wildwood",
-      area: 3000
-    }
-
-    const { body } = await request(app)
-      .post("/api/plots/user/1")
-      .send(newPlot)
-      .set("Authorization", `Bearer ${token}`)
-      .expect(403)
-
-    expect(body).toMatchObject({
-      message: "Forbidden",
-      details: "Permission to create plot denied"
-    })
-  })
-
   test("POST:404 Responds with an error message when the owner_id does not exist", async () => {
 
     const newPlot = {
-      owner_id: 1,
       name: "John's Field",
       type: "field",
       description: "A large field",
@@ -398,7 +366,6 @@ describe("POST /api/plots/user/:owner_id", () => {
   test("POST:409 Responds with an error message when the plot name already exists for one of the given user's plots", async () => {
 
     const newPlot = {
-      owner_id: 1,
       name: "John's Garden",
       type: "garden",
       description: "The garden at the new house",

--- a/src/__tests__/subdivisions.test.ts
+++ b/src/__tests__/subdivisions.test.ts
@@ -175,10 +175,9 @@ describe("GET /api/subdivisions/plot/:plot_id?type=", () => {
 
 describe("POST /api/subdivisions/plot/:plot_id", () => {
 
-  test("POST:201 Responds with a new subdivision object", async () => {
+  test("POST:201 Responds with a new subdivision object, assigning plot_id automatically", async () => {
 
     const newSubdivision = {
-      plot_id: 1,
       name: "Wildflowers",
       type: "flowerbed",
       description: "Foxgloves and bluebells",
@@ -204,7 +203,6 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
   test("POST:201 Assigns a null value to 'area' when no value is provided", async () => {
 
     const newSubdivision = {
-      plot_id: 1,
       name: "Wildflowers",
       type: "flowerbed",
       description: "Foxgloves and bluebells"
@@ -222,7 +220,6 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
   test("POST:201 Ignores any unnecessary properties on the object", async () => {
 
     const newSubdivision = {
-      plot_id: 1,
       name: "Wildflowers",
       type: "flowerbed",
       description: "Foxgloves and bluebells",
@@ -242,7 +239,6 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
   test("POST:400 Responds with an error when passed a property with an invalid data type", async () => {
 
     const newSubdivision = {
-      plot_id: 1,
       name: "Wildflowers",
       type: "flowerbed",
       description: "Foxgloves and bluebells",
@@ -264,7 +260,6 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
   test("POST:400 Responds with an error when a required property is missing from the request body", async () => {
 
     const newSubdivision = {
-      plot_id: 1,
       type: "flowerbed",
       description: "Foxgloves and bluebells",
       area: 2
@@ -285,7 +280,6 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
   test("POST:400 Responds with an error when passed an invalid subdivision type", async () => {
 
     const newSubdivision = {
-      plot_id: 1,
       name: "Wildflowers",
       type: "garage",
       description: "Foxgloves and bluebells",
@@ -307,7 +301,6 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
   test("POST:400 Responds with an error message when the plot_id is not a positive integer", async () => {
 
     const newSubdivision = {
-      plot_id: 1,
       name: "Wildflowers",
       type: "flowerbed",
       description: "Foxgloves and bluebells",
@@ -329,7 +322,6 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
   test("POST:403 Responds with a warning when the authenticated user attempts to create a subdivision for another user", async () => {
 
     const newSubdivision = {
-      plot_id: 1,
       name: "Wildflowers",
       type: "flowerbed",
       description: "Foxgloves and bluebells",
@@ -348,32 +340,9 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
     })
   })
 
-  test("POST:403 Responds with a warning when the authenticated user attempts to create a subdivision for another user (forbidden plot_id on request body)", async () => {
-
-    const newSubdivision = {
-      plot_id: 2,
-      name: "Wildflowers",
-      type: "flowerbed",
-      description: "Foxgloves and bluebells",
-      area: 2
-    }
-
-    const { body } = await request(app)
-      .post("/api/subdivisions/plot/1")
-      .send(newSubdivision)
-      .set("Authorization", `Bearer ${token}`)
-      .expect(403)
-
-    expect(body).toMatchObject({
-      message: "Forbidden",
-      details: "Permission to create subdivision denied"
-    })
-  })
-
   test("POST:404 Responds with an error message when the plot_id does not exist", async () => {
 
     const newSubdivision = {
-      plot_id: 1,
       name: "Wildflowers",
       type: "flowerbed",
       description: "Foxgloves and bluebells",
@@ -395,7 +364,6 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
   test("POST:409 Responds with an error message when the subdivision name already exists for one of the given user's subdivisions of that plot", async () => {
 
     const newSubdivision = {
-      plot_id: 1,
       name: "Onion Bed",
       type: "flowerbed",
       description: "Foxgloves and bluebells",

--- a/src/controllers/crop-controllers.ts
+++ b/src/controllers/crop-controllers.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Response } from "express"
-import { insertCropByPlotId, selectCropsByPlotId, selectCropsBySubdivisionId } from "../models/crop-models"
+import { insertCropByPlotId, insertCropBySubdivisionId, selectCropsByPlotId, selectCropsBySubdivisionId } from "../models/crop-models"
 import { ExtendedRequest } from "../types/auth-types"
 
 
@@ -42,6 +42,21 @@ export const getCropsBySubdivisionId = async (req: ExtendedRequest, res: Respons
   try {
     const [crops, count] = await selectCropsBySubdivisionId(authUserId, +subdivision_id, req.query)
     res.status(200).send({ crops, count })
+  } catch (err) {
+    next(err)
+  }
+}
+
+
+export const postCropBySubdivisionId = async (req: ExtendedRequest, res: Response, next: NextFunction) => {
+
+  const authUserId: number = req.user!.user_id
+
+  const { subdivision_id } = req.params
+
+  try {
+    const crop = await insertCropBySubdivisionId(authUserId, +subdivision_id, req.body)
+    res.status(201).send({ crop })
   } catch (err) {
     next(err)
   }

--- a/src/models/crop-models.ts
+++ b/src/models/crop-models.ts
@@ -1,6 +1,6 @@
 import QueryString from "qs"
 import { db } from "../db"
-import { Crop } from "../types/crop-types"
+import { Crop, CropRequest } from "../types/crop-types"
 import { getPlotOwnerId, getSubdivisionPlotId } from "../utils/db-query-utils"
 import { verifyPagination, verifyParamIsPositiveInt, verifyPermission } from "../utils/verification-utils"
 import format from "pg-format"
@@ -107,7 +107,7 @@ export const selectCropsByPlotId = async (
 export const insertCropByPlotId = async (
   authUserId: number,
   plot_id: number,
-  crop: Crop
+  crop: CropRequest
 ) => {
 
   await verifyParamIsPositiveInt(plot_id)
@@ -127,7 +127,7 @@ export const insertCropByPlotId = async (
       %L
     RETURNING *;
     `,
-    [[plot_id, crop.subdivision_id, crop.name, crop.variety, crop.quantity, crop.date_planted, crop.harvest_date]]
+    [[plot_id, null, crop.name, crop.variety, crop.quantity, crop.date_planted, crop.harvest_date]]
   ))
 
   return result.rows[0]
@@ -233,7 +233,7 @@ export const selectCropsBySubdivisionId = async (
 export const insertCropBySubdivisionId = async (
   authUserId: number,
   subdivision_id: number,
-  crop: Crop
+  crop: CropRequest
 ) => {
 
   await verifyParamIsPositiveInt(subdivision_id)

--- a/src/models/crop-models.ts
+++ b/src/models/crop-models.ts
@@ -116,7 +116,7 @@ export const insertCropByPlotId = async (
 
   await verifyPermission(authUserId, owner_id, "Permission to add crop denied")
 
-  owner_id = await getPlotOwnerId(crop.plot_id)
+  owner_id = await getPlotOwnerId(plot_id)
 
   await verifyPermission(authUserId, owner_id, "Permission to add crop denied")
 
@@ -127,7 +127,7 @@ export const insertCropByPlotId = async (
       %L
     RETURNING *;
     `,
-    [[crop.plot_id, crop.subdivision_id, crop.name, crop.variety, crop.quantity, crop.date_planted, crop.harvest_date]]
+    [[plot_id, crop.subdivision_id, crop.name, crop.variety, crop.quantity, crop.date_planted, crop.harvest_date]]
   ))
 
   return result.rows[0]
@@ -227,4 +227,32 @@ export const selectCropsBySubdivisionId = async (
   const countResult = await db.query(`${countQuery};`, [subdivision_id])
 
   return Promise.all([result.rows, +countResult.rows[0].count])
+}
+
+
+export const insertCropBySubdivisionId = async (
+  authUserId: number,
+  subdivision_id: number,
+  crop: Crop
+) => {
+
+  await verifyParamIsPositiveInt(subdivision_id)
+
+  const plotId = await getSubdivisionPlotId(subdivision_id)
+
+  const owner_id = await getPlotOwnerId(plotId)
+
+  await verifyPermission(authUserId, owner_id, "Permission to add crop denied")
+
+  const result = await db.query(format(`
+    INSERT INTO crops
+      (plot_id, subdivision_id, name, variety, quantity, date_planted, harvest_date)
+    VALUES
+      %L
+    RETURNING *;
+    `,
+    [[plotId, subdivision_id, crop.name, crop.variety, crop.quantity, crop.date_planted, crop.harvest_date]]
+  ))
+
+  return result.rows[0]
 }

--- a/src/models/plot-models.ts
+++ b/src/models/plot-models.ts
@@ -58,8 +58,6 @@ export const insertPlotByOwner = async (
 
   await verifyPermission(authUserId, owner_id, "Permission to create plot denied")
 
-  await verifyPermission(authUserId, plot.owner_id, "Permission to create plot denied")
-
   await checkPlotNameConflict(owner_id, plot.name)
 
   const isValidPlotType = await validatePlotType(plot.type)
@@ -79,7 +77,7 @@ export const insertPlotByOwner = async (
       %L
     RETURNING *;
     `,
-    [[plot.owner_id, plot.name, plot.type, plot.description, plot.location, plot.area]]
+    [[owner_id, plot.name, plot.type, plot.description, plot.location, plot.area]]
   ))
 
   return result.rows[0]

--- a/src/models/plot-models.ts
+++ b/src/models/plot-models.ts
@@ -1,7 +1,7 @@
 import QueryString from "qs"
 import { db } from "../db"
 import format from "pg-format"
-import { Plot } from "../types/plot-types"
+import { Plot, PlotRequest } from "../types/plot-types"
 import { checkPlotNameConflict, getPlotOwnerId, searchForUserId, validatePlotType } from "../utils/db-query-utils"
 import { verifyPermission, verifyParamIsPositiveInt } from "../utils/verification-utils"
 
@@ -49,7 +49,7 @@ export const selectPlotsByOwner = async (
 export const insertPlotByOwner = async (
   authUserId: number,
   owner_id: number,
-  plot: Plot
+  plot: PlotRequest
 ): Promise<Plot> => {
 
   await verifyParamIsPositiveInt(owner_id)
@@ -109,7 +109,7 @@ export const selectPlotByPlotId = async (
 export const updatePlotByPlotId = async (
   authUserId: number,
   plot_id: number,
-  plot: Plot
+  plot: PlotRequest
 ): Promise<Plot> => {
 
   await verifyParamIsPositiveInt(plot_id)

--- a/src/models/subdivision-models.ts
+++ b/src/models/subdivision-models.ts
@@ -2,7 +2,7 @@ import QueryString from "qs"
 import { db } from "../db"
 import { checkSubdivisionNameConflict, getPlotOwnerId, getSubdivisionPlotId, validateSubdivisionType } from "../utils/db-query-utils"
 import { verifyPermission, verifyParamIsPositiveInt } from "../utils/verification-utils"
-import { Subdivision } from "../types/subdivision-types"
+import { Subdivision, SubdivisionRequest } from "../types/subdivision-types"
 import format from "pg-format"
 
 
@@ -49,7 +49,7 @@ export const selectSubdivisionsByPlotId = async (
 export const insertSubdivisionByPlotId = async (
   authUserId: number,
   plot_id: number,
-  subdivision: Subdivision
+  subdivision: SubdivisionRequest
 ): Promise<Subdivision> => {
 
   await verifyParamIsPositiveInt(plot_id)
@@ -115,7 +115,7 @@ export const selectSubdivisionBySubdivisionId = async (
 export const updateSubdivisionBySubdivisionId = async (
   authUserId: number,
   subdivision_id: number,
-  subdivision: Subdivision
+  subdivision: SubdivisionRequest
 ): Promise<Subdivision> => {
 
   await verifyParamIsPositiveInt(subdivision_id)

--- a/src/models/subdivision-models.ts
+++ b/src/models/subdivision-models.ts
@@ -58,7 +58,7 @@ export const insertSubdivisionByPlotId = async (
 
   await verifyPermission(authUserId, owner_id, "Permission to create subdivision denied")
 
-  owner_id = await getPlotOwnerId(subdivision.plot_id)
+  owner_id = await getPlotOwnerId(plot_id)
 
   await verifyPermission(authUserId, owner_id, "Permission to create subdivision denied")
 
@@ -81,7 +81,7 @@ export const insertSubdivisionByPlotId = async (
       %L
     RETURNING *;
     `,
-    [[subdivision.plot_id, subdivision.name, subdivision.type, subdivision.description, subdivision.area]]
+    [[plot_id, subdivision.name, subdivision.type, subdivision.description, subdivision.area]]
   ))
 
   return result.rows[0]

--- a/src/routes/crops-router.ts
+++ b/src/routes/crops-router.ts
@@ -1,6 +1,6 @@
 import { Router } from "express"
 import { verifyToken } from "../middleware/authentication"
-import { getCropsByPlotId, getCropsBySubdivisionId, postCropByPlotId } from "../controllers/crop-controllers"
+import { getCropsByPlotId, getCropsBySubdivisionId, postCropByPlotId, postCropBySubdivisionId } from "../controllers/crop-controllers"
 
 
 export const cropsRouter = Router()
@@ -107,13 +107,6 @@ cropsRouter.route("/crops/plot/:plot_id")
  *          schema:
  *            type: object
  *            properties:
- *              plot_id:
- *                type: integer
- *                example: 1
- *              subdivision_id:
- *                type: integer
- *                nullable: true
- *                example: null
  *              name:
  *                type: string
  *                example: carrot
@@ -275,3 +268,76 @@ cropsRouter.route("/crops/subdivision/:subdivision_id")
  *              $ref: "#/components/schemas/NotFound"
  */
   .get(verifyToken, getCropsBySubdivisionId)
+
+
+/**
+ * @swagger
+ * /api/crops/subdivision/{subdivision_id}:
+ *  post:
+ *    security:
+ *      - bearerAuth: []
+ *    summary: Add a new crop to a subdivision
+ *    description: Responds with a crop object. If the subdivision_id does not exist, the server responds with an error. Permission is denied when the plot does not belong to the current user.
+ *    tags: [Crops]
+ *    parameters:
+ *      - in: path
+ *        name: subdivision_id
+ *        required: true
+ *        schema:
+ *          type: integer
+ *    requestBody:
+ *      required: true
+ *      content:
+ *        application/json:
+ *          schema:
+ *            type: object
+ *            properties:
+ *              name:
+ *                type: string
+ *                example: carrot
+ *              variety:
+ *                type: string
+ *                nullable: true
+ *                example: chantenay
+ *              quantity:
+ *                type: integer
+ *                nullable: true
+ *                example: 20
+ *              date_planted:
+ *                type: string
+ *                nullable: true
+ *                example: 2024-06-19
+ *              harvest_date:
+ *                type: string
+ *                nullable: true
+ *                example: 2024-09-14
+ *    responses:
+ *      201:
+ *        description: OK
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                crop:
+ *                  $ref: "#/components/schemas/Crop"
+ *      400:
+ *        description: Bad Request
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/BadRequest"
+ *      403:
+ *        description: Forbidden
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/Forbidden"
+ *      404:
+ *        description: Not Found
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/NotFound"
+ */
+  .post(verifyToken, postCropBySubdivisionId)

--- a/src/routes/crops-router.ts
+++ b/src/routes/crops-router.ts
@@ -277,7 +277,7 @@ cropsRouter.route("/crops/subdivision/:subdivision_id")
  *    security:
  *      - bearerAuth: []
  *    summary: Add a new crop to a subdivision
- *    description: Responds with a crop object. If the subdivision_id does not exist, the server responds with an error. Permission is denied when the plot does not belong to the current user.
+ *    description: Responds with a crop object. If the subdivision_id does not exist, the server responds with an error. Permission is denied when the subdivision does not belong to the current user.
  *    tags: [Crops]
  *    parameters:
  *      - in: path

--- a/src/routes/plots-router.ts
+++ b/src/routes/plots-router.ts
@@ -84,9 +84,6 @@ plotsRouter.route("/plots/user/:owner_id")
  *          schema:
  *            type: object
  *            properties:
- *              owner_id:
- *                type: integer
- *                example: 1
  *              name:
  *                type: string
  *                example: John's Garden

--- a/src/routes/subdivisions-router.ts
+++ b/src/routes/subdivisions-router.ts
@@ -84,9 +84,6 @@ subdivisionsRouter.route("/subdivisions/plot/:plot_id")
  *          schema:
  *            type: object
  *            properties:
- *              plot_id:
- *                type: integer
- *                example: 1
  *              name:
  *                type: string
  *                example: Root Vegetable Bed

--- a/src/types/crop-types.ts
+++ b/src/types/crop-types.ts
@@ -8,3 +8,12 @@ export type Crop = {
   date_planted: Date | null
   harvest_date: Date | null
 }
+
+
+export type CropRequest = {
+  name: string
+  variety?: string | null
+  quantity?: number | null
+  date_planted?: Date | null
+  harvest_date?: Date | null
+}

--- a/src/types/plot-types.ts
+++ b/src/types/plot-types.ts
@@ -7,3 +7,12 @@ export type Plot = {
   location: string
   area: number | null
 }
+
+
+export type PlotRequest = {
+  name: string
+  type: string
+  description: string
+  location: string
+  area?: number | null
+}

--- a/src/types/subdivision-types.ts
+++ b/src/types/subdivision-types.ts
@@ -6,3 +6,11 @@ export type Subdivision = {
   description: string
   area: number | null
 }
+
+
+export type SubdivisionRequest = {
+  name: string
+  type: string
+  description: string
+  area?: number | null
+}


### PR DESCRIPTION
### MVC

- Added new router and route to post to `/api/crops/subdivision/:subdivision_id`
- Added `postCropBySubdivisionId` controller
- Added `insertCropBySubdivisionId` model

### Tests

- Added tests for POST /api/crops/subdivision/:subdivision_id

### Validation

- Updates models for posting new crops, subdivisions, and plots to assign specific properties (e.g. plot_id, subdivision_id) using parameter values rather than a property on the request body

### Types

- Adds new `PlotRequest`, `SubdivisionRequest`, and `CropRequest` custom types for more rigorous type checking
- Uses new types on plot, subdivision, and crop models for post and patch requests