### PR TITLE
Get subdivisions queries

### DIFF
--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -3,7 +3,7 @@ import { db } from "../db"
 import { seed } from "../db/seeding/seed"
 import request from "supertest"
 import { app } from "../app"
-import { Crop, ExtendedCrop } from "../types/crop-types"
+import { ExtendedCrop } from "../types/crop-types"
 import { toBeOneOf } from 'jest-extended'
 expect.extend({ toBeOneOf })
 
@@ -214,7 +214,7 @@ describe("GET /api/crops/plot/:plot_id?sort=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedCrops = [...body.crops].sort((a: Crop, b: Crop) => {
+    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.name > b.name) return 1
       if (a.name < b.name) return -1
       return 0
@@ -236,7 +236,7 @@ describe("GET /api/crops/plot/:plot_id?sort=", () => {
       expect(crop.date_planted).not.toBeNull()
     }
 
-    const sortedCrops = [...body.crops].sort((a: Crop, b: Crop) => {
+    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.date_planted! < b.date_planted!) return 1
       if (a.date_planted! > b.date_planted!) return -1
       return 0
@@ -258,7 +258,7 @@ describe("GET /api/crops/plot/:plot_id?sort=", () => {
       expect(crop.date_planted).not.toBeNull()
     }
 
-    const sortedCrops = [...body.crops].sort((a: Crop, b: Crop) => {
+    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.harvest_date! < b.harvest_date!) return 1
       if (a.harvest_date! > b.harvest_date!) return -1
       return 0
@@ -297,7 +297,7 @@ describe("GET /api/crops/plot/:plot_id?name=&sort=", () => {
       expect(crop.name).toMatch(/ca/i)
     }
 
-    const sortedCrops = [...body.crops].sort((a: Crop, b: Crop) => {
+    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.name > b.name) return 1
       if (a.name < b.name) return -1
       return 0
@@ -319,7 +319,7 @@ describe("GET /api/crops/plot/:plot_id?name=&sort=", () => {
       expect(crop.name).toMatch(/ca/i)
     }
 
-    const sortedCrops = [...body.crops].sort((a: Crop, b: Crop) => {
+    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.harvest_date! < b.harvest_date!) return 1
       if (a.harvest_date! > b.harvest_date!) return -1
       return 0
@@ -399,7 +399,7 @@ describe("GET /api/crops/plot/:plot_id?page=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    expect(body.crops.map((crop: Crop) => {
+    expect(body.crops.map((crop: ExtendedCrop) => {
       return crop.crop_id
     })).toEqual([2, 1])
 
@@ -413,7 +413,7 @@ describe("GET /api/crops/plot/:plot_id?page=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    expect(body.crops.map((crop: Crop) => {
+    expect(body.crops.map((crop: ExtendedCrop) => {
       return crop.crop_id
     })).toEqual([4, 3])
 
@@ -427,7 +427,7 @@ describe("GET /api/crops/plot/:plot_id?page=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    expect(body.crops.map((crop: Crop) => {
+    expect(body.crops.map((crop: ExtendedCrop) => {
       return crop.crop_id
     })).toEqual([1])
 
@@ -645,7 +645,7 @@ describe("GET /api/crops/subdivision/:subdivision_id", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedCrops = [...body.crops].sort((a: Crop, b: Crop) => {
+    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.crop_id! < b.crop_id!) return 1
       if (a.crop_id! > b.crop_id!) return -1
       return 0
@@ -798,7 +798,7 @@ describe("GET /api/crops/subdivision/:subdivision_id?sort=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedCrops = [...body.crops].sort((a: Crop, b: Crop) => {
+    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.name > b.name) return 1
       if (a.name < b.name) return -1
       return 0
@@ -820,7 +820,7 @@ describe("GET /api/crops/subdivision/:subdivision_id?sort=", () => {
       expect(crop.date_planted).not.toBeNull()
     }
 
-    const sortedCrops = [...body.crops].sort((a: Crop, b: Crop) => {
+    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.date_planted! < b.date_planted!) return 1
       if (a.date_planted! > b.date_planted!) return -1
       return 0
@@ -842,7 +842,7 @@ describe("GET /api/crops/subdivision/:subdivision_id?sort=", () => {
       expect(crop.date_planted).not.toBeNull()
     }
 
-    const sortedCrops = [...body.crops].sort((a: Crop, b: Crop) => {
+    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.harvest_date! < b.harvest_date!) return 1
       if (a.harvest_date! > b.harvest_date!) return -1
       return 0
@@ -881,7 +881,7 @@ describe("GET /api/crops/subdivision/:subdivision_id?name=&sort=", () => {
       expect(crop.name).toMatch(/car/i)
     }
 
-    const sortedCrops = [...body.crops].sort((a: Crop, b: Crop) => {
+    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.name > b.name) return 1
       if (a.name < b.name) return -1
       return 0
@@ -903,7 +903,7 @@ describe("GET /api/crops/subdivision/:subdivision_id?name=&sort=", () => {
       expect(crop.name).toMatch(/car/i)
     }
 
-    const sortedCrops = [...body.crops].sort((a: Crop, b: Crop) => {
+    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.harvest_date! < b.harvest_date!) return 1
       if (a.harvest_date! > b.harvest_date!) return -1
       return 0
@@ -983,7 +983,7 @@ describe("GET /api/crops/subdivision/:subdivision_id?page=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    expect(body.crops.map((crop: Crop) => {
+    expect(body.crops.map((crop: ExtendedCrop) => {
       return crop.crop_id
     })).toEqual([1])
 
@@ -997,7 +997,7 @@ describe("GET /api/crops/subdivision/:subdivision_id?page=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    expect(body.crops.map((crop: Crop) => {
+    expect(body.crops.map((crop: ExtendedCrop) => {
       return crop.crop_id
     })).toEqual([4])
 

--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -3,7 +3,7 @@ import { db } from "../db"
 import { seed } from "../db/seeding/seed"
 import request from "supertest"
 import { app } from "../app"
-import { Crop } from "../types/crop-types"
+import { Crop, ExtendedCrop } from "../types/crop-types"
 import { toBeOneOf } from 'jest-extended'
 expect.extend({ toBeOneOf })
 
@@ -42,7 +42,7 @@ describe("GET /api/crops/plot/:plot_id", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedCrops = [...body.crops].sort((a: Crop, b: Crop) => {
+    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.crop_id! < b.crop_id!) return 1
       if (a.crop_id! > b.crop_id!) return -1
       return 0

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -343,7 +343,7 @@ describe("GET /api/plots/user/:owner_id?limit=", () => {
 
 describe("GET /api/plots/user/:owner_id?page=", () => {
 
-  test("GET:200 Responds with an array of plot objects associated with the plot beginning from the page set in the query parameter", async () => {
+  test("GET:200 Responds with an array of plot objects associated with the owner beginning from the page set in the query parameter", async () => {
 
     const { body } = await request(app)
       .get("/api/plots/user/1?limit=2&page=2")

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -4,7 +4,7 @@ import { seed } from "../db/seeding/seed"
 import request from "supertest"
 import { app } from "../app"
 import { toBeOneOf } from 'jest-extended'
-import { ExtendedPlot, Plot } from "../types/plot-types"
+import { ExtendedPlot } from "../types/plot-types"
 expect.extend({ toBeOneOf })
 
 
@@ -257,7 +257,7 @@ describe("GET /api/plots/user/:owner_id?sort=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedPlots = [...body.plots].sort((a: Plot, b: Plot) => {
+    const sortedPlots = [...body.plots].sort((a: ExtendedPlot, b: ExtendedPlot) => {
       if (a.name! > b.name!) return 1
       if (a.name! < b.name!) return -1
       return 0
@@ -350,7 +350,7 @@ describe("GET /api/plots/user/:owner_id?page=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    expect(body.plots.map((crop: Plot) => {
+    expect(body.plots.map((crop: ExtendedPlot) => {
       return crop.plot_id
     })).toEqual([1])
 
@@ -364,7 +364,7 @@ describe("GET /api/plots/user/:owner_id?page=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    expect(body.plots.map((crop: Plot) => {
+    expect(body.plots.map((crop: ExtendedPlot) => {
       return crop.plot_id
     })).toEqual([4, 3])
 

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -4,7 +4,7 @@ import { seed } from "../db/seeding/seed"
 import request from "supertest"
 import { app } from "../app"
 import { toBeOneOf } from 'jest-extended'
-import { Plot } from "../types/plot-types"
+import { ExtendedPlot, Plot } from "../types/plot-types"
 expect.extend({ toBeOneOf })
 
 
@@ -40,7 +40,7 @@ describe("GET /api/plots/user/:owner_id", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedPlots = [...body.plots].sort((a: Plot, b: Plot) => {
+    const sortedPlots = [...body.plots].sort((a: ExtendedPlot, b: ExtendedPlot) => {
       if (a.plot_id! < b.plot_id!) return 1
       if (a.plot_id! > b.plot_id!) return -1
       return 0

--- a/src/__tests__/subdivisions.test.ts
+++ b/src/__tests__/subdivisions.test.ts
@@ -324,6 +324,73 @@ describe("GET /api/subdivisions/plot/:plot_id?limit=", () => {
 })
 
 
+describe("GET /api/subdivisions/plot/:plot_id?page=", () => {
+
+  test("GET:200 Responds with an array of subdivisions objects associated with the plot beginning from the page set in the query parameter", async () => {
+
+    const { body } = await request(app)
+      .get("/api/subdivisions/plot/1?limit=2&page=2")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+
+    expect(body.subdivisions.map((subdivision: Subdivision) => {
+      return subdivision.subdivision_id
+    })).toEqual([1])
+  })
+
+  test("GET:200 The page defaults to page one", async () => {
+
+    const { body } = await request(app)
+      .get("/api/subdivisions/plot/1?limit=2")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+
+    expect(body.subdivisions.map((subdivision: Subdivision) => {
+      return subdivision.subdivision_id
+    })).toEqual([3, 2])
+  })
+
+  test("GET:400 Responds with an error when the value of page is not a positive integer", async () => {
+
+    const { body } = await request(app)
+      .get("/api/subdivisions/plot/1?limit=2&page=two")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject({
+      message: "Bad Request",
+      details: "Invalid parameter"
+    })
+  })
+
+  test("GET:404 Responds with an error when the page cannot be found", async () => {
+
+    const { body } = await request(app)
+      .get("/api/subdivisions/plot/1?limit=2&page=3")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(404)
+
+    expect(body).toMatchObject({
+      message: "Not Found",
+      details: "Page not found"
+    })
+  })
+
+  test("GET:404 Responds with an error when the page cannot be found (multiple queries affecting total query result rows)", async () => {
+
+    const { body } = await request(app)
+      .get("/api/subdivisions/plot/1?type=bed&name=onion&limit=1&page=2")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(404)
+
+    expect(body).toMatchObject({
+      message: "Not Found",
+      details: "Page not found"
+    })
+  })
+})
+
+
 describe("POST /api/subdivisions/plot/:plot_id", () => {
 
   test("POST:201 Responds with a new subdivision object, assigning plot_id automatically", async () => {

--- a/src/__tests__/subdivisions.test.ts
+++ b/src/__tests__/subdivisions.test.ts
@@ -58,6 +58,8 @@ describe("GET /api/subdivisions/plot/:plot_id", () => {
         area: expect.toBeOneOf([expect.any(Number), null])
       })
     }
+
+    expect(body.count).toBe(3)
   })
 
   test("GET:200 Responds with an empty array when no subdivisions are associated with the plot_id", async () => {
@@ -70,6 +72,8 @@ describe("GET /api/subdivisions/plot/:plot_id", () => {
     expect(Array.isArray(body.subdivisions)).toBe(true)
 
     expect(body.subdivisions).toHaveLength(0)
+
+    expect(body.count).toBe(0)
   })
 
   test("GET:400 Responds with an error message when the plot_id is not a positive integer", async () => {
@@ -163,6 +167,8 @@ describe("GET /api/subdivisions/plot/:plot_id?type=", () => {
     for (const subdivision of body.subdivisions) {
       expect(subdivision.type).toBe("bed")
     }
+
+    expect(body.count).toBe(2)
   })
 
   test("GET:404 Responds with an error message when the query value is invalid", async () => {
@@ -192,6 +198,8 @@ describe("GET /api/subdivisions/plot/:plot_id?name=", () => {
     for (const subdivision of body.subdivisions) {
       expect(subdivision.name).toMatch(/bed/i)
     }
+
+    expect(body.count).toBe(2)
   })
 
   test("GET:200 Filtered results are case-insensitive", async () => {
@@ -204,6 +212,8 @@ describe("GET /api/subdivisions/plot/:plot_id?name=", () => {
     for (const subdivision of body.subdivisions) {
       expect(subdivision.name).toMatch(/bed/i)
     }
+
+    expect(body.count).toBe(2)
   })
 
   test("GET:200 Returns an empty array when the value of name matches no results", async () => {
@@ -216,6 +226,8 @@ describe("GET /api/subdivisions/plot/:plot_id?name=", () => {
     expect(Array.isArray(body.subdivisions)).toBe(true)
 
     expect(body.subdivisions).toHaveLength(0)
+
+    expect(body.count).toBe(0)
   })
 })
 
@@ -233,6 +245,8 @@ describe("GET /api/subdivisions/plot/:plot_id?type=&name=", () => {
       expect(subdivision.type).toBe("bed")
       expect(subdivision.name).toMatch(/onion/i)
     }
+
+    expect(body.count).toBe(1)
   })
 })
 
@@ -253,6 +267,8 @@ describe("GET /api/subdivisions/plot/:plot_id?sort=", () => {
     })
 
     expect(body.subdivisions).toEqual(sortedSubdivisions)
+
+    expect(body.count).toBe(3)
   })
 
   test("GET:404 Responds with an error when passed an invalid sort value", async () => {
@@ -297,6 +313,8 @@ describe("GET /api/subdivisions/plot/:plot_id?limit=", () => {
       .expect(200)
 
     expect(body.subdivisions).toHaveLength(2)
+
+    expect(body.count).toBe(3)
   })
 
   test("GET:200 Responds with an array of all subdivisions associated with the plot when the limit exceeds the total number of results", async () => {
@@ -307,6 +325,8 @@ describe("GET /api/subdivisions/plot/:plot_id?limit=", () => {
       .expect(200)
 
     expect(body.subdivisions).toHaveLength(3)
+
+    expect(body.count).toBe(3)
   })
 
   test("GET:400 Responds with an error message when the value of limit is not a positive integer", async () => {
@@ -336,6 +356,8 @@ describe("GET /api/subdivisions/plot/:plot_id?page=", () => {
     expect(body.subdivisions.map((subdivision: Subdivision) => {
       return subdivision.subdivision_id
     })).toEqual([1])
+
+    expect(body.count).toBe(3)
   })
 
   test("GET:200 The page defaults to page one", async () => {
@@ -348,6 +370,8 @@ describe("GET /api/subdivisions/plot/:plot_id?page=", () => {
     expect(body.subdivisions.map((subdivision: Subdivision) => {
       return subdivision.subdivision_id
     })).toEqual([3, 2])
+
+    expect(body.count).toBe(3)
   })
 
   test("GET:400 Responds with an error when the value of page is not a positive integer", async () => {

--- a/src/__tests__/subdivisions.test.ts
+++ b/src/__tests__/subdivisions.test.ts
@@ -4,7 +4,7 @@ import { seed } from "../db/seeding/seed"
 import request from "supertest"
 import { app } from "../app"
 import { toBeOneOf } from 'jest-extended'
-import { Subdivision } from "../types/subdivision-types"
+import { ExtendedSubdivision } from "../types/subdivision-types"
 expect.extend({ toBeOneOf })
 
 
@@ -40,7 +40,7 @@ describe("GET /api/subdivisions/plot/:plot_id", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedSubdivisions = [...body.subdivisions].sort((a: Subdivision, b: Subdivision) => {
+    const sortedSubdivisions = [...body.subdivisions].sort((a: ExtendedSubdivision, b: ExtendedSubdivision) => {
       if (a.subdivision_id! < b.subdivision_id!) return 1
       if (a.subdivision_id! > b.subdivision_id!) return -1
       return 0
@@ -264,7 +264,7 @@ describe("GET /api/subdivisions/plot/:plot_id?sort=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedSubdivisions = [...body.subdivisions].sort((a: Subdivision, b: Subdivision) => {
+    const sortedSubdivisions = [...body.subdivisions].sort((a: ExtendedSubdivision, b: ExtendedSubdivision) => {
       if (a.name! > b.name!) return 1
       if (a.name! < b.name!) return -1
       return 0
@@ -357,7 +357,7 @@ describe("GET /api/subdivisions/plot/:plot_id?page=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    expect(body.subdivisions.map((subdivision: Subdivision) => {
+    expect(body.subdivisions.map((subdivision: ExtendedSubdivision) => {
       return subdivision.subdivision_id
     })).toEqual([1])
 
@@ -371,7 +371,7 @@ describe("GET /api/subdivisions/plot/:plot_id?page=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    expect(body.subdivisions.map((subdivision: Subdivision) => {
+    expect(body.subdivisions.map((subdivision: ExtendedSubdivision) => {
       return subdivision.subdivision_id
     })).toEqual([3, 2])
 

--- a/src/__tests__/subdivisions.test.ts
+++ b/src/__tests__/subdivisions.test.ts
@@ -287,6 +287,43 @@ describe("GET /api/subdivisions/plot/:plot_id?order=", () => {
 })
 
 
+describe("GET /api/subdivisions/plot/:plot_id?limit=", () => {
+
+  test("GET:200 Responds with a limited array of subdivision objects associated with the plot", async () => {
+
+    const { body } = await request(app)
+      .get("/api/subdivisions/plot/1?limit=2")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+
+    expect(body.subdivisions).toHaveLength(2)
+  })
+
+  test("GET:200 Responds with an array of all subdivisions associated with the plot when the limit exceeds the total number of results", async () => {
+
+    const { body } = await request(app)
+      .get("/api/subdivisions/plot/1?limit=20")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+
+    expect(body.subdivisions).toHaveLength(3)
+  })
+
+  test("GET:400 Responds with an error message when the value of limit is not a positive integer", async () => {
+
+    const { body } = await request(app)
+      .get("/api/subdivisions/plot/1?limit=two")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject({
+      message: "Bad Request",
+      details: "Invalid parameter"
+    })
+  })
+})
+
+
 describe("POST /api/subdivisions/plot/:plot_id", () => {
 
   test("POST:201 Responds with a new subdivision object, assigning plot_id automatically", async () => {

--- a/src/__tests__/subdivisions.test.ts
+++ b/src/__tests__/subdivisions.test.ts
@@ -55,7 +55,11 @@ describe("GET /api/subdivisions/plot/:plot_id", () => {
         name: expect.any(String),
         type: expect.any(String),
         description: expect.any(String),
-        area: expect.toBeOneOf([expect.any(Number), null])
+        area: expect.toBeOneOf([expect.any(Number), null]),
+        image_count: expect.any(Number),
+        crop_count: expect.any(Number),
+        issue_count: expect.any(Number),
+        job_count: expect.any(Number)
       })
     }
 

--- a/src/__tests__/utils/verification.test.ts
+++ b/src/__tests__/utils/verification.test.ts
@@ -1,4 +1,4 @@
-import { verifyPermission, verifyParamIsPositiveInt, verifyPagination } from "../../utils/verification"
+import { verifyPermission, verifyParamIsPositiveInt, verifyPagination, verifyQueryValues } from "../../utils/verification"
 
 
 describe("verifyPermission", () => {
@@ -83,5 +83,23 @@ describe("verifyParamIsPositiveInt", () => {
   test("Returns undefined when the value of the parameter is a positive integer", () => {
 
     expect(verifyParamIsPositiveInt(1)).toBeUndefined()
+  })
+})
+
+
+describe("verifyQueryValues", () => {
+
+  test("When the query value is not found in the array of valid values, the promise is rejected", () => {
+
+    expect(verifyQueryValues(["foo", "bar"], "example")).rejects.toMatchObject({
+      status: 404,
+      message: "Not Found",
+      details: "No results found for that query"
+    })
+  })
+
+  test("Returns undefined when the query value is found in the array of valid values", () => {
+
+    expect(verifyQueryValues(["foo", "bar"], "foo")).toBeUndefined()
   })
 })

--- a/src/__tests__/utils/verification.test.ts
+++ b/src/__tests__/utils/verification.test.ts
@@ -1,4 +1,4 @@
-import { verifyPermission, verifyParamIsPositiveInt, verifyPagination, verifyQueryValues } from "../../utils/verification"
+import { verifyPermission, verifyParamIsPositiveInt, verifyPagination, verifyQueryValue } from "../../utils/verification"
 
 
 describe("verifyPermission", () => {
@@ -87,11 +87,11 @@ describe("verifyParamIsPositiveInt", () => {
 })
 
 
-describe("verifyQueryValues", () => {
+describe("verifyQueryValue", () => {
 
   test("When the query value is not found in the array of valid values, the promise is rejected", () => {
 
-    expect(verifyQueryValues(["foo", "bar"], "example")).rejects.toMatchObject({
+    expect(verifyQueryValue(["foo", "bar"], "example")).rejects.toMatchObject({
       status: 404,
       message: "Not Found",
       details: "No results found for that query"
@@ -100,6 +100,6 @@ describe("verifyQueryValues", () => {
 
   test("Returns undefined when the query value is found in the array of valid values", () => {
 
-    expect(verifyQueryValues(["foo", "bar"], "foo")).toBeUndefined()
+    expect(verifyQueryValue(["foo", "bar"], "foo")).toBeUndefined()
   })
 })

--- a/src/controllers/subdivisions-controllers.ts
+++ b/src/controllers/subdivisions-controllers.ts
@@ -10,8 +10,8 @@ export const getSubdivisionsByPlotId = async (req: ExtendedRequest, res: Respons
   const { plot_id } = req.params
 
   try {
-    const subdivisions = await selectSubdivisionsByPlotId(authUserId, +plot_id, req.query)
-    res.status(200).send({ subdivisions })
+    const [subdivisions, count] = await selectSubdivisionsByPlotId(authUserId, +plot_id, req.query)
+    res.status(200).send({ subdivisions, count })
   } catch (err) {
     next(err)
   }

--- a/src/models/crops-models.ts
+++ b/src/models/crops-models.ts
@@ -2,7 +2,7 @@ import QueryString from "qs"
 import { db } from "../db"
 import { Crop, CropRequest, ExtendedCrop } from "../types/crop-types"
 import { getPlotOwnerId, getSubdivisionPlotId } from "../utils/db-queries"
-import { verifyPagination, verifyParamIsPositiveInt, verifyPermission, verifyQueryValues } from "../utils/verification"
+import { verifyPagination, verifyParamIsPositiveInt, verifyPermission, verifyQueryValue } from "../utils/verification"
 import format from "pg-format"
 
 
@@ -28,9 +28,9 @@ export const selectCropsByPlotId = async (
 
   await verifyPermission(authUserId, owner_id, "Permission to view crop data denied")
 
-  await verifyQueryValues(["crop_id", "name", "date_planted", "harvest_date"], sort as string)
+  await verifyQueryValue(["crop_id", "name", "date_planted", "harvest_date"], sort as string)
 
-  await verifyQueryValues(["asc", "desc"], order as string)
+  await verifyQueryValue(["asc", "desc"], order as string)
 
   let query = `
   SELECT
@@ -145,9 +145,9 @@ export const selectCropsBySubdivisionId = async (
 
   await verifyPermission(authUserId, owner_id, "Permission to view crop data denied")
 
-  await verifyQueryValues(["crop_id", "name", "date_planted", "harvest_date"], sort as string)
+  await verifyQueryValue(["crop_id", "name", "date_planted", "harvest_date"], sort as string)
 
-  await verifyQueryValues(["asc", "desc"], order as string)
+  await verifyQueryValue(["asc", "desc"], order as string)
 
   let query = `
   SELECT

--- a/src/models/crops-models.ts
+++ b/src/models/crops-models.ts
@@ -89,7 +89,7 @@ export const selectCropsByPlotId = async (
   }
 
   query += `
-  ORDER BY ${sort} ${order}, name
+  ORDER BY ${sort} ${order}, crops.name
   LIMIT ${limit}
   OFFSET ${(+page - 1) * +limit}
   `
@@ -211,7 +211,7 @@ export const selectCropsBySubdivisionId = async (
   }
 
   query += `
-  ORDER BY ${sort} ${order}, name
+  ORDER BY ${sort} ${order}, crops.name
   LIMIT ${limit}
   OFFSET ${(+page - 1) * +limit}
   `

--- a/src/models/crops-models.ts
+++ b/src/models/crops-models.ts
@@ -2,7 +2,7 @@ import QueryString from "qs"
 import { db } from "../db"
 import { Crop, CropRequest, ExtendedCrop } from "../types/crop-types"
 import { getPlotOwnerId, getSubdivisionPlotId } from "../utils/db-queries"
-import { verifyPagination, verifyParamIsPositiveInt, verifyPermission } from "../utils/verification"
+import { verifyPagination, verifyParamIsPositiveInt, verifyPermission, verifyQueryValues } from "../utils/verification"
 import format from "pg-format"
 
 
@@ -28,18 +28,9 @@ export const selectCropsByPlotId = async (
 
   await verifyPermission(authUserId, owner_id, "Permission to view crop data denied")
 
-  const validValues = {
-    sort: ["crop_id", "name", "date_planted", "harvest_date"],
-    order: ["asc", "desc"]
-  }
+  await verifyQueryValues(["crop_id", "name", "date_planted", "harvest_date"], sort as string)
 
-  if (!validValues.sort.includes(sort as string) || !validValues.order.includes(order as string)) {
-    return Promise.reject({
-      status: 404,
-      message: "Not Found",
-      details: "No results found for that query"
-    })
-  }
+  await verifyQueryValues(["asc", "desc"], order as string)
 
   let query = `
   SELECT
@@ -154,18 +145,9 @@ export const selectCropsBySubdivisionId = async (
 
   await verifyPermission(authUserId, owner_id, "Permission to view crop data denied")
 
-  const validValues = {
-    sort: ["crop_id", "name", "date_planted", "harvest_date"],
-    order: ["asc", "desc"]
-  }
+  await verifyQueryValues(["crop_id", "name", "date_planted", "harvest_date"], sort as string)
 
-  if (!validValues.sort.includes(sort as string) || !validValues.order.includes(order as string)) {
-    return Promise.reject({
-      status: 404,
-      message: "Not Found",
-      details: "No results found for that query"
-    })
-  }
+  await verifyQueryValues(["asc", "desc"], order as string)
 
   let query = `
   SELECT

--- a/src/models/plots-models.ts
+++ b/src/models/plots-models.ts
@@ -112,7 +112,7 @@ export const selectPlotsByOwner = async (
   }
 
   query += `
-  ORDER BY ${sort} ${order}, name
+  ORDER BY ${sort} ${order}, plots.name
   LIMIT ${limit}
   OFFSET ${(+page - 1) * +limit}
   `

--- a/src/models/plots-models.ts
+++ b/src/models/plots-models.ts
@@ -3,7 +3,7 @@ import { db } from "../db"
 import format from "pg-format"
 import { ExtendedPlot, Plot, PlotRequest } from "../types/plot-types"
 import { checkPlotNameConflict, getPlotOwnerId, searchForUserId, validatePlotType } from "../utils/db-queries"
-import { verifyPermission, verifyParamIsPositiveInt, verifyPagination, verifyQueryValues } from "../utils/verification"
+import { verifyPermission, verifyParamIsPositiveInt, verifyPagination, verifyQueryValue } from "../utils/verification"
 
 
 export const selectPlotsByOwner = async (
@@ -29,9 +29,9 @@ export const selectPlotsByOwner = async (
 
   await verifyPermission(authUserId, owner_id, "Permission to view plot data denied")
 
-  await verifyQueryValues(["plot_id", "name"], sort as string)
+  await verifyQueryValue(["plot_id", "name"], sort as string)
 
-  await verifyQueryValues(["asc", "desc"], order as string)
+  await verifyQueryValue(["asc", "desc"], order as string)
 
   const isValidPlotType = await validatePlotType(type as string)
 

--- a/src/models/plots-models.ts
+++ b/src/models/plots-models.ts
@@ -3,7 +3,7 @@ import { db } from "../db"
 import format from "pg-format"
 import { ExtendedPlot, Plot, PlotRequest } from "../types/plot-types"
 import { checkPlotNameConflict, getPlotOwnerId, searchForUserId, validatePlotType } from "../utils/db-queries"
-import { verifyPermission, verifyParamIsPositiveInt, verifyPagination } from "../utils/verification"
+import { verifyPermission, verifyParamIsPositiveInt, verifyPagination, verifyQueryValues } from "../utils/verification"
 
 
 export const selectPlotsByOwner = async (
@@ -29,18 +29,9 @@ export const selectPlotsByOwner = async (
 
   await verifyPermission(authUserId, owner_id, "Permission to view plot data denied")
 
-  const validValues = {
-    sort: ["plot_id", "name"],
-    order: ["asc", "desc"]
-  }
+  await verifyQueryValues(["plot_id", "name"], sort as string)
 
-  if (!validValues.sort.includes(sort as string) || !validValues.order.includes(order as string)) {
-    return Promise.reject({
-      status: 404,
-      message: "Not Found",
-      details: "No results found for that query"
-    })
-  }
+  await verifyQueryValues(["asc", "desc"], order as string)
 
   const isValidPlotType = await validatePlotType(type as string)
 

--- a/src/models/plots-models.ts
+++ b/src/models/plots-models.ts
@@ -42,6 +42,16 @@ export const selectPlotsByOwner = async (
     })
   }
 
+  const isValidPlotType = await validatePlotType(type as string)
+
+  if (type && !isValidPlotType) {
+    return Promise.reject({
+      status: 404,
+      message: "Not Found",
+      details: "No results found for that query"
+    })
+  }
+
   let query = `
   SELECT
     plots.*,
@@ -82,16 +92,6 @@ export const selectPlotsByOwner = async (
     countQuery += format(`
       AND plots.name ILIKE %L
       `, `%${name}%`)
-  }
-
-  const isValidPlotType = await validatePlotType(type as string)
-
-  if (type && !isValidPlotType) {
-    return Promise.reject({
-      status: 404,
-      message: "Not Found",
-      details: "No results found for that query"
-    })
   }
 
   if (type) {

--- a/src/models/subdivisions-models.ts
+++ b/src/models/subdivisions-models.ts
@@ -13,11 +13,14 @@ export const selectSubdivisionsByPlotId = async (
     name,
     type,
     sort = "subdivision_id",
-    order = "desc"
+    order = "desc",
+    limit = "10"
   }: QueryString.ParsedQs
 ): Promise<Subdivision[]> => {
 
   await verifyParamIsPositiveInt(plot_id)
+
+  await verifyParamIsPositiveInt(+limit)
 
   const owner_id = await getPlotOwnerId(plot_id)
 
@@ -61,6 +64,7 @@ export const selectSubdivisionsByPlotId = async (
 
   query += `
   ORDER BY ${sort} ${order}, subdivisions.name
+  LIMIT ${limit}
   `
 
   const result = await db.query(`${query};`, [plot_id])

--- a/src/models/subdivisions-models.ts
+++ b/src/models/subdivisions-models.ts
@@ -1,7 +1,7 @@
 import QueryString from "qs"
 import { db } from "../db"
 import { checkSubdivisionNameConflict, getPlotOwnerId, getSubdivisionPlotId, validateSubdivisionType } from "../utils/db-queries"
-import { verifyPermission, verifyParamIsPositiveInt } from "../utils/verification"
+import { verifyPermission, verifyParamIsPositiveInt, verifyQueryValues } from "../utils/verification"
 import { Subdivision, SubdivisionRequest } from "../types/subdivision-types"
 import format from "pg-format"
 
@@ -23,18 +23,9 @@ export const selectSubdivisionsByPlotId = async (
 
   await verifyPermission(authUserId, owner_id, "Permission to view plot subdivision data denied")
 
-  const validValues = {
-    sort: ["subdivision_id", "name"],
-    order: ["asc", "desc"]
-  }
+  await verifyQueryValues(["subdivision_id", "name"], sort as string)
 
-  if (!validValues.sort.includes(sort as string) || !validValues.order.includes(order as string)) {
-    return Promise.reject({
-      status: 404,
-      message: "Not Found",
-      details: "No results found for that query"
-    })
-  }
+  await verifyQueryValues(["asc", "desc"], order as string)
 
   const isValidSubdivisionType = await validateSubdivisionType(type as string)
 

--- a/src/models/subdivisions-models.ts
+++ b/src/models/subdivisions-models.ts
@@ -2,7 +2,7 @@ import QueryString from "qs"
 import { db } from "../db"
 import { checkSubdivisionNameConflict, getPlotOwnerId, getSubdivisionPlotId, validateSubdivisionType } from "../utils/db-queries"
 import { verifyPermission, verifyParamIsPositiveInt, verifyQueryValue, verifyPagination } from "../utils/verification"
-import { Subdivision, SubdivisionRequest } from "../types/subdivision-types"
+import { ExtendedSubdivision, Subdivision, SubdivisionRequest } from "../types/subdivision-types"
 import format from "pg-format"
 
 
@@ -17,7 +17,7 @@ export const selectSubdivisionsByPlotId = async (
     limit = "10",
     page = "1"
   }: QueryString.ParsedQs
-): Promise<[Subdivision[], number]> => {
+): Promise<[ExtendedSubdivision[], number]> => {
 
   await verifyParamIsPositiveInt(plot_id)
 

--- a/src/models/subdivisions-models.ts
+++ b/src/models/subdivisions-models.ts
@@ -1,7 +1,7 @@
 import QueryString from "qs"
 import { db } from "../db"
 import { checkSubdivisionNameConflict, getPlotOwnerId, getSubdivisionPlotId, validateSubdivisionType } from "../utils/db-queries"
-import { verifyPermission, verifyParamIsPositiveInt, verifyQueryValues } from "../utils/verification"
+import { verifyPermission, verifyParamIsPositiveInt, verifyQueryValue } from "../utils/verification"
 import { Subdivision, SubdivisionRequest } from "../types/subdivision-types"
 import format from "pg-format"
 
@@ -23,9 +23,9 @@ export const selectSubdivisionsByPlotId = async (
 
   await verifyPermission(authUserId, owner_id, "Permission to view plot subdivision data denied")
 
-  await verifyQueryValues(["subdivision_id", "name"], sort as string)
+  await verifyQueryValue(["subdivision_id", "name"], sort as string)
 
-  await verifyQueryValues(["asc", "desc"], order as string)
+  await verifyQueryValue(["asc", "desc"], order as string)
 
   const isValidSubdivisionType = await validateSubdivisionType(type as string)
 

--- a/src/models/subdivisions-models.ts
+++ b/src/models/subdivisions-models.ts
@@ -44,9 +44,26 @@ export const selectSubdivisionsByPlotId = async (
   }
 
   let query = `
-  SELECT * 
+  SELECT
+    subdivisions.*,
+    COUNT(DISTINCT subdivision_images.image_id)::INT
+    AS image_count,
+    COUNT(DISTINCT crops.crop_id)::INT
+    AS crop_count,
+    COUNT(DISTINCT issues.issue_id)::INT
+    AS issue_count,
+    COUNT(DISTINCT jobs.job_id)::INT
+    AS job_count
   FROM subdivisions
-  WHERE plot_id = $1
+  LEFT JOIN subdivision_images
+  ON subdivisions.subdivision_id = subdivision_images.subdivision_id
+  LEFT JOIN crops
+  ON subdivisions.subdivision_id = crops.subdivision_id
+  LEFT JOIN issues
+  ON subdivisions.subdivision_id = issues.subdivision_id
+  LEFT JOIN jobs
+  ON subdivisions.subdivision_id = jobs.subdivision_id
+  WHERE subdivisions.plot_id = $1
   `
 
   let countQuery = `
@@ -72,6 +89,10 @@ export const selectSubdivisionsByPlotId = async (
       AND subdivisions.type = %L
       `, type)
   }
+
+  query += `
+  GROUP BY subdivisions.subdivision_id
+  `
 
   if (sort === "name") {
     order = "asc"

--- a/src/routes/plots-router.ts
+++ b/src/routes/plots-router.ts
@@ -36,7 +36,7 @@ plotsRouter.route("/plots/user/:owner_id")
  *        name: sort
  *        schema:
  *          type: string
- *        default: crop_id
+ *        default: plot_id
  *      - in: query
  *        name: order
  *        schema:

--- a/src/routes/subdivisions-router.ts
+++ b/src/routes/subdivisions-router.ts
@@ -25,9 +25,33 @@ subdivisionsRouter.route("/subdivisions/plot/:plot_id")
  *        schema:
  *          type: integer
  *      - in: query
+ *        name: name
+ *        schema:
+ *          type: string
+ *      - in: query
  *        name: type
  *        schema:
  *          type: string
+ *      - in: query
+ *        name: sort
+ *        schema:
+ *          type: string
+ *        default: subdivision_id
+ *      - in: query
+ *        name: order
+ *        schema:
+ *          type: string
+ *        default: desc
+ *      - in: query
+ *        name: limit
+ *        schema:
+ *          type: integer
+ *        default: 10
+ *      - in: query
+ *        name: page
+ *        schema:
+ *          type: integer
+ *        default: 1
  *    responses:
  *      200:
  *        description: OK
@@ -39,7 +63,25 @@ subdivisionsRouter.route("/subdivisions/plot/:plot_id")
  *                subdivisions:
  *                  type: array
  *                  items:
- *                    $ref: "#/components/schemas/Subdivision"
+ *                    allOf:
+ *                      - $ref: "#/components/schemas/Subdivision"
+ *                      - type: object
+ *                        properties:
+ *                          image_count:
+ *                            type: integer
+ *                            example: 1
+ *                          crop_count:
+ *                            type: integer
+ *                            example: 5
+ *                          issue_count:
+ *                            type: integer
+ *                            example: 3
+ *                          job_count:
+ *                            type: integer
+ *                            example: 0
+ *                count:
+ *                  type: integer
+ *                  example: 1
  *      400:
  *        description: Bad Request
  *        content:

--- a/src/types/subdivision-types.ts
+++ b/src/types/subdivision-types.ts
@@ -8,6 +8,14 @@ export type Subdivision = {
 }
 
 
+export type ExtendedSubdivision = {
+  image_count: number
+  crop_count: number
+  issue_count: number
+  job_count: number
+} & Subdivision
+
+
 export type SubdivisionRequest = {
   name: string
   type: string

--- a/src/utils/verification.ts
+++ b/src/utils/verification.ts
@@ -43,7 +43,7 @@ export const verifyPermission = (
 }
 
 
-export const verifyQueryValues = (
+export const verifyQueryValue = (
   validValues: string[],
   queryValue: string
 ): Promise<never> | undefined => {

--- a/src/utils/verification.ts
+++ b/src/utils/verification.ts
@@ -41,3 +41,18 @@ export const verifyPermission = (
     })
   }
 }
+
+
+export const verifyQueryValues = (
+  validValues: string[],
+  queryValue: string
+): Promise<never> | undefined => {
+
+  if (!validValues.includes(queryValue)) {
+    return Promise.reject({
+      status: 404,
+      message: "Not Found",
+      details: "No results found for that query"
+    })
+  }
+}


### PR DESCRIPTION
### selectSubdivisionsByPlotId (model)

- Updated possible query parameters to include `sort`, `order`, `name`, `limit`, `page`
- Updated SQL query to handle sorting and ordering
- Updated SQL query to filter results by name
- Updated SQL query to handle limits and pagination
- Added SQL query to return a total count for pagination purposes
- Extended SQL query to return image, crop, issue, and job counts for each subdivision
- Updated and expanded test suite accordingly

### getSubdivisionsByPlotId (controller)

- Modified controller to receive and send `subdivisions` and `count`

### Utils

- Added `verifyQueryValue` to check a query value against an array of acceptable values
- Updated models to use new util

### Types

- Added new `ExtendedSubdivision` type with count properties