### PR TITLE
Get subdivision query extension

### DIFF
--- a/src/__tests__/subdivisions.test.ts
+++ b/src/__tests__/subdivisions.test.ts
@@ -645,7 +645,12 @@ describe("GET /api/subdivisions/:subdivision_id", () => {
       name: "Root Vegetable Bed",
       type: "bed",
       description: "Carrots, beetroots, and parsnips",
-      area: 10
+      area: 10,
+      plot_name: "John's Garden",
+      image_count: 1,
+      crop_count: 2,
+      issue_count: 1,
+      job_count: 1
     })
   })
 

--- a/src/routes/subdivisions-router.ts
+++ b/src/routes/subdivisions-router.ts
@@ -190,7 +190,25 @@ subdivisionsRouter.route("/subdivisions/:subdivision_id")
  *              type: object
  *              properties:
  *                subdivision:
- *                  $ref: "#/components/schemas/Subdivision"
+ *                  allOf:
+ *                    - $ref: "#/components/schemas/Subdivision"
+ *                    - type: object
+ *                      properties:
+ *                        plot_name:
+ *                          type: string
+ *                          example: "John's Garden"
+ *                        image_count:
+ *                          type: integer
+ *                          example: 1
+ *                        crop_count:
+ *                          type: integer
+ *                          example: 5
+ *                        issue_count:
+ *                          type: integer
+ *                          example: 3
+ *                        job_count:
+ *                          type: integer
+ *                          example: 0
  *      400:
  *        description: Bad Request
  *        content:

--- a/src/types/subdivision-types.ts
+++ b/src/types/subdivision-types.ts
@@ -9,6 +9,7 @@ export type Subdivision = {
 
 
 export type ExtendedSubdivision = {
+  plot_name?: string
   image_count: number
   crop_count: number
   issue_count: number


### PR DESCRIPTION
### Summary

- Extended SQL query in `selectSubdivisionBySubdivisionId` to return counts on subdivision object
- Updated test case and JSDoc annotations accordingly
- Added optional `plot_name` property to `ExtendedSubdivision` type