### PR TITLE
Pinned plots

### DIFF
--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -57,6 +57,7 @@ describe("GET /api/plots/user/:owner_id", () => {
         description: expect.any(String),
         location: expect.any(String),
         area: expect.toBeOneOf([expect.any(Number), null]),
+        is_pinned: expect.any(Boolean),
         image_count: expect.any(Number),
         subdivision_count: expect.any(Number),
         crop_count: expect.any(Number),
@@ -414,7 +415,7 @@ describe("GET /api/plots/user/:owner_id?page=", () => {
 
 describe("POST /api/plots/user/:owner_id", () => {
 
-  test("POST:201 Responds with a new plot object, assigning owner_id automatically", async () => {
+  test("POST:201 Responds with a new plot object, assigning owner_id and is_pinned automatically", async () => {
 
     const newPlot = {
       name: "John's Field",
@@ -437,11 +438,12 @@ describe("POST /api/plots/user/:owner_id", () => {
       type: "field",
       description: "A large field",
       location: "Wildwood",
-      area: 3000
+      area: 3000,
+      is_pinned: false
     })
   })
 
-  test("POST:201 Assigns a null value to 'area' when no value is provided", async () => {
+  test("POST:201 Assigns a null value to area when no value is provided", async () => {
 
     const newPlot = {
       name: "John's Field",
@@ -651,6 +653,7 @@ describe("GET /api/plots/:plot_id", () => {
       description: "A vegetable garden",
       location: "Farmville",
       area: 100,
+      is_pinned: true,
       image_count: 1,
       subdivision_count: 3,
       crop_count: 4,
@@ -725,7 +728,8 @@ describe("PATCH /api/plots/:plot_id", () => {
       type: "homestead",
       description: "A homestead",
       location: "Farmville",
-      area: 1200
+      area: 1200,
+      is_pinned: true
     })
   })
 
@@ -752,7 +756,8 @@ describe("PATCH /api/plots/:plot_id", () => {
       type: "garden",
       description: "A new description",
       location: "234, Apricot Avenue, Farmville",
-      area: 180
+      area: 180,
+      is_pinned: true
     })
   })
 

--- a/src/db/data/development-data/plots/plots.ts
+++ b/src/db/data/development-data/plots/plots.ts
@@ -8,7 +8,8 @@ export const plotData: Plot[] = [
     type: "field",
     description: "The admin's field",
     location: "Example location",
-    area: 100
+    area: 100,
+    is_pinned: true
   },
   {
     owner_id: 1,
@@ -16,6 +17,7 @@ export const plotData: Plot[] = [
     type: "allotment",
     description: "The admin's allotment",
     location: "Example location",
-    area: null
+    area: null,
+    is_pinned: false
   }
 ]

--- a/src/db/data/test-data/plots/plots.ts
+++ b/src/db/data/test-data/plots/plots.ts
@@ -8,7 +8,8 @@ export const plotData: Plot[] = [
     type: "garden",
     description: "A vegetable garden",
     location: "Farmville",
-    area: 100
+    area: 100,
+    is_pinned: true
   },
   {
     owner_id: 2,
@@ -16,7 +17,8 @@ export const plotData: Plot[] = [
     type: "field",
     description: "An orchard",
     location: "Lemongrove",
-    area: 500
+    area: 500,
+    is_pinned: true
   },
   {
     owner_id: 1,
@@ -24,7 +26,8 @@ export const plotData: Plot[] = [
     type: "allotment",
     description: "An allotment",
     location: "Farmville",
-    area: 50
+    area: 50,
+    is_pinned: false
   },
   {
     owner_id: 1,
@@ -32,6 +35,7 @@ export const plotData: Plot[] = [
     type: "allotment",
     description: "A second allotment",
     location: "Farmville",
-    area: 40
+    area: 40,
+    is_pinned: false
   }
 ]

--- a/src/db/seeding/seed.ts
+++ b/src/db/seeding/seed.ts
@@ -113,7 +113,8 @@ export const seed = async (
       type VARCHAR NOT NULL,
       description VARCHAR NOT NULL,
       location VARCHAR NOT NULL,
-      area INT
+      area INT,
+      is_pinned BOOLEAN NOT NULL DEFAULT FALSE
     );
     `)
 
@@ -195,7 +196,7 @@ export const seed = async (
       subdivision_id INT REFERENCES subdivisions(subdivision_id) ON DELETE CASCADE,
       title VARCHAR NOT NULL,
       description VARCHAR NOT NULL,
-      is_resolved BOOLEAN DEFAULT FALSE
+      is_resolved BOOLEAN NOT NULL DEFAULT FALSE
     );
     `)
 
@@ -227,8 +228,8 @@ export const seed = async (
       description VARCHAR NOT NULL,
       date_added DATE DEFAULT NOW(),
       deadline DATE,
-      is_started BOOLEAN DEFAULT FALSE,
-      is_completed BOOLEAN DEFAULT FALSE
+      is_started BOOLEAN NOT NULL DEFAULT FALSE,
+      is_completed BOOLEAN NOT NULL DEFAULT FALSE
     );
     `)
 
@@ -262,7 +263,7 @@ export const seed = async (
 
   await db.query(format(`
     INSERT INTO plots 
-      (owner_id, name, type, description, location, area)
+      (owner_id, name, type, description, location, area, is_pinned)
     VALUES %L;
     `,
     plotData.map(entry => Object.values(entry))

--- a/src/routes/swagger-schemas.ts
+++ b/src/routes/swagger-schemas.ts
@@ -123,6 +123,9 @@ export const schemaRouter = Router()
  *          type: integer
  *          nullable: true
  *          example: 100
+ *        is_pinned:
+ *          type: boolean
+ *          example: true
  *    PlotRequest:
  *      type: object
  *      properties:

--- a/src/types/plot-types.ts
+++ b/src/types/plot-types.ts
@@ -6,6 +6,7 @@ export type Plot = {
   description: string
   location: string
   area: number | null
+  is_pinned: boolean
 }
 
 


### PR DESCRIPTION
### Types

- Added `is_pinned` property to `Plot` type

### Database

- Updated test and dev data for plots to include `is_pinned` property on plot objects
- Updated seed to add and populate `is_pinned` row on plots table
- Updated seed to make `BOOLEAN DEFAULT FALSE` -> `BOOLEAN NOT NULL DEFAULT FALSE` for relevant fields in issues and jobs

### Tests

- Updated existing plot tests to handle new `is_pinned` property on plot objects

### Swagger

- Added `is_pinned` to `Plot` schema
- Updated JSDoc annotations for plots accordingly