### PR TITLE
Get pinned plots

### DIFF
--- a/src/controllers/plots-controllers.ts
+++ b/src/controllers/plots-controllers.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Response } from "express"
-import { insertPlotByOwner, removePlotByPlotId, selectPlotByPlotId, selectPlotsByOwner, updatePlotByPlotId } from "../models/plots-models"
+import { insertPlotByOwner, removePlotByPlotId, selectPinnedPlotsByOwner, selectPlotByPlotId, selectPlotsByOwner, updatePlotByPlotId } from "../models/plots-models"
 import { ExtendedRequest } from "../types/auth-types"
 
 
@@ -27,6 +27,21 @@ export const postPlotByOwner = async (req: ExtendedRequest, res: Response, next:
   try {
     const plot = await insertPlotByOwner(authUserId, +owner_id, req.body)
     res.status(201).send({ plot })
+  } catch (err) {
+    next(err)
+  }
+}
+
+
+export const getPinnedPlotsByOwner = async (req: ExtendedRequest, res: Response, next: NextFunction) => {
+
+  const authUserId = req.user!.user_id
+
+  const { owner_id } = req.params
+
+  try {
+    const plots = await selectPinnedPlotsByOwner(authUserId, +owner_id)
+    res.status(200).send({ plots })
   } catch (err) {
     next(err)
   }

--- a/src/db/data/test-data/plots/plots.ts
+++ b/src/db/data/test-data/plots/plots.ts
@@ -18,7 +18,7 @@ export const plotData: Plot[] = [
     description: "An orchard",
     location: "Lemongrove",
     area: 500,
-    is_pinned: true
+    is_pinned: false
   },
   {
     owner_id: 1,
@@ -27,7 +27,7 @@ export const plotData: Plot[] = [
     description: "An allotment",
     location: "Farmville",
     area: 50,
-    is_pinned: false
+    is_pinned: true
   },
   {
     owner_id: 1,

--- a/src/models/plots-models.ts
+++ b/src/models/plots-models.ts
@@ -156,6 +156,30 @@ export const insertPlotByOwner = async (
 }
 
 
+export const selectPinnedPlotsByOwner = async (
+  authUserId: number,
+  owner_id: number,
+): Promise<Plot[]> => {
+
+  await verifyParamIsPositiveInt(owner_id)
+
+  await searchForUserId(owner_id)
+
+  await verifyPermission(authUserId, owner_id, "Permission to view pinned plot data denied")
+
+  const result = await db.query(`
+    SELECT *
+    FROM plots
+    WHERE owner_id = $1
+    AND is_pinned IS TRUE
+    ORDER BY name ASC;
+    `,
+    [owner_id])
+
+  return result.rows
+}
+
+
 export const selectPlotByPlotId = async (
   authUserId: number,
   plot_id: number

--- a/src/routes/plots-router.ts
+++ b/src/routes/plots-router.ts
@@ -1,6 +1,6 @@
 import { Router } from "express"
 import { verifyToken } from "../middleware/authentication"
-import { deletePlotByPlotId, getPlotByPlotId, getPlotsByOwner, patchPlotByPlotId, postPlotByOwner } from "../controllers/plots-controllers"
+import { deletePlotByPlotId, getPinnedPlotsByOwner, getPlotByPlotId, getPlotsByOwner, patchPlotByPlotId, postPlotByOwner } from "../controllers/plots-controllers"
 
 
 export const plotsRouter = Router()
@@ -164,6 +164,58 @@ plotsRouter.route("/plots/user/:owner_id")
  *              $ref: "#/components/schemas/Conflict"
  */
   .post(verifyToken, postPlotByOwner)
+
+
+plotsRouter.route("/plots/user/:owner_id/pinned")
+
+
+/**
+ * @swagger
+ * /api/plots/user/{owner_id}/pinned:
+ *  get:
+ *    security:
+ *      - bearerAuth: []
+ *    summary: Retrieve a user's pinned plots
+ *    description: Responds with an array of plot objects. If the owner_id does not exist, the server responds with an error. Permission is denied when the current user's ID does not match the target owner_id.
+ *    tags: [Plots]
+ *    parameters:
+ *      - in: path
+ *        name: owner_id
+ *        required: true
+ *        schema:
+ *          type: integer
+ *    responses:
+ *      200:
+ *        description: OK
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                plots:
+ *                  type: array
+ *                  items:
+ *                    $ref: "#/components/schemas/Plot"
+ *      400:
+ *        description: Bad Request
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/BadRequest"
+ *      403:
+ *        description: Forbidden
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/Forbidden"
+ *      404:
+ *        description: Not Found
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/NotFound"
+ */
+  .get(verifyToken, getPinnedPlotsByOwner)
 
 
 plotsRouter.route("/plots/:plot_id")


### PR DESCRIPTION
### Summary

- Added new `/api//plots/user/:owner_id/pinned` router and route to get pinned plots with JSDoc annotations
- Added `getPinnedPlotsByOwner` controller
- Added `selectPinnedPlotsByOwner` model to retrieve a user's pinned plots
- Added tests for GET /api/plots/user/:owner_id/pinned