### PR TITLE
Patch pinned plots

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,9 @@ The following scripts are included in the `package.json` file:
 > Runs the TypeScript compiler and seeds the database.
 
 `npm run start`
-> Runs the TypeScript compiler and starts the server locally on port 9090.
+> Runs the TypeScript compiler and starts the server locally on port 9090. 
+
+> Swagger documentation is then served up at `http://localhost:9090/api/docs/`
 
 `npm t`
 > Runs all tests in the `src` directory serially.

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -1158,7 +1158,7 @@ describe("PATCH /api/plots/:plot_id/pin", () => {
     })
   })
 
-  test("PATCH:400 Responds with an error when the value of toggle is not true (boolean data type)", async () => {
+  test("PATCH:400 Responds with an error when the value of bool is not true (boolean data type)", async () => {
 
     const toggles = [
       { bool: false },

--- a/src/controllers/plots-controllers.ts
+++ b/src/controllers/plots-controllers.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Response } from "express"
-import { insertPlotByOwner, removePlotByPlotId, selectPinnedPlotsByOwner, selectPlotByPlotId, selectPlotsByOwner, updatePlotByPlotId } from "../models/plots-models"
+import { insertPlotByOwner, removePlotByPlotId, selectPinnedPlotsByOwner, selectPlotByPlotId, selectPlotsByOwner, updateIsPinnedByPlotId, updatePlotByPlotId } from "../models/plots-models"
 import { ExtendedRequest } from "../types/auth-types"
 
 
@@ -87,6 +87,21 @@ export const deletePlotByPlotId = async (req: ExtendedRequest, res: Response, ne
   try {
     await removePlotByPlotId(authUserId, +plot_id)
     res.status(204).send()
+  } catch (err) {
+    next(err)
+  }
+}
+
+
+export const patchIsPinnedByPlotId = async (req: ExtendedRequest, res: Response, next: NextFunction) => {
+
+  const authUserId = req.user!.user_id
+
+  const { plot_id } = req.params
+
+  try {
+    const response = await updateIsPinnedByPlotId(authUserId, +plot_id, req.body)
+    res.status(200).send(response)
   } catch (err) {
     next(err)
   }

--- a/src/routes/plots-router.ts
+++ b/src/routes/plots-router.ts
@@ -1,6 +1,6 @@
 import { Router } from "express"
 import { verifyToken } from "../middleware/authentication"
-import { deletePlotByPlotId, getPinnedPlotsByOwner, getPlotByPlotId, getPlotsByOwner, patchPlotByPlotId, postPlotByOwner } from "../controllers/plots-controllers"
+import { deletePlotByPlotId, getPinnedPlotsByOwner, getPlotByPlotId, getPlotsByOwner, patchIsPinnedByPlotId, patchPlotByPlotId, postPlotByOwner } from "../controllers/plots-controllers"
 
 
 export const plotsRouter = Router()
@@ -383,3 +383,74 @@ plotsRouter.route("/plots/:plot_id")
  *              $ref: "#/components/schemas/NotFound"
  */
   .delete(verifyToken, deletePlotByPlotId)
+
+
+plotsRouter.route("/plots/:plot_id/pin")
+
+
+/**
+ * @swagger
+ * /api/plots/{plot_id}/pin:
+ *  patch:
+ *    security:
+ *      - bearerAuth: []
+ *    summary: Pin or unpin a plot
+ *    description: Responds with a success message. If the maximum number of plots are already pinned or the plot_id does not exist, the server responds with an error. Permission is denied when the plot does not belong to the current user.
+ *    tags: [Plots]
+ *    parameters:
+ *      - in: path
+ *        name: plot_id
+ *        required: true
+ *        schema:
+ *          type: integer
+ *    requestBody:
+ *      required: true
+ *      content:
+ *        application/json:
+ *          schema:
+ *            type: object
+ *            properties:
+ *              bool:
+ *                type: boolean
+ *                example: true
+ *    responses:
+ *      200:
+ *        description: OK
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                message:
+ *                  type: string
+ *                details:
+ *                  type: string
+ *            examples:
+ *              Plot pinned:
+ *                value:
+ *                  message: OK
+ *                  details: Plot pinned successfully
+ *              Plot unpinned:
+ *                value:
+ *                  message: OK
+ *                  details: Plot unpinned successfully
+ *      400:
+ *        description: Bad Request
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/BadRequest"
+ *      403:
+ *        description: Forbidden
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/Forbidden"
+ *      404:
+ *        description: Not Found
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/NotFound"
+ */
+  .patch(verifyToken, patchIsPinnedByPlotId)


### PR DESCRIPTION
### Summary

- Added new `/api/plots/:plot_id/pin` router and route to pin / unpin plots
- Added `patchIsPinnedByPlotId` controller
- Added `updateIsPinnedByPlotId` model to pin and unpin plots, limiting pinned plots to 4 per user
- Added tests for PATCH /api/plots/:plot_id/pin