### PR TITLE
Get crops image count

### DIFF
--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -61,7 +61,8 @@ describe("GET /api/crops/plot/:plot_id", () => {
         date_planted: expect.toBeOneOf([expect.stringMatching(regex), null]),
         harvest_date: expect.toBeOneOf([expect.stringMatching(regex), null]),
         subdivision_name: expect.toBeOneOf([expect.any(String), null]),
-        note_count: expect.any(Number)
+        note_count: expect.any(Number),
+        image_count: expect.any(Number)
       })
     }
 
@@ -663,7 +664,8 @@ describe("GET /api/crops/subdivision/:subdivision_id", () => {
         quantity: expect.toBeOneOf([expect.any(Number), null]),
         date_planted: expect.toBeOneOf([expect.stringMatching(regex), null]),
         harvest_date: expect.toBeOneOf([expect.stringMatching(regex), null]),
-        note_count: expect.any(Number)
+        note_count: expect.any(Number),
+        image_count: expect.any(Number)
       })
     }
 

--- a/src/models/crops-models.ts
+++ b/src/models/crops-models.ts
@@ -37,13 +37,17 @@ export const selectCropsByPlotId = async (
     crops.*,
     subdivisions.name
     AS subdivision_name,
-    COUNT(crop_notes.crop_id)::INT
-    AS note_count
+    COUNT(DISTINCT crop_notes.note_id)::INT
+    AS note_count,
+    COUNT(DISTINCT crop_images.image_id)::INT
+    AS image_count
   FROM crops
   LEFT JOIN subdivisions
   ON crops.subdivision_id = subdivisions.subdivision_id
   LEFT JOIN crop_notes
   ON crops.crop_id = crop_notes.crop_id
+  LEFT JOIN crop_images
+  ON crops.crop_id = crop_images.crop_id
   WHERE crops.plot_id = $1
   `
 
@@ -152,11 +156,15 @@ export const selectCropsBySubdivisionId = async (
   let query = `
   SELECT
     crops.*,
-    COUNT(crop_notes.crop_id)::INT
-    AS note_count
+    COUNT(DISTINCT crop_notes.note_id)::INT
+    AS note_count,
+    COUNT(DISTINCT crop_images.image_id)::INT
+    AS image_count
   FROM crops
   LEFT JOIN crop_notes
   ON crops.crop_id = crop_notes.crop_id
+  LEFT JOIN crop_images
+  ON crops.crop_id = crop_images.crop_id
   WHERE crops.subdivision_id = $1
   `
 

--- a/src/routes/crops-router.ts
+++ b/src/routes/crops-router.ts
@@ -69,6 +69,9 @@ cropsRouter.route("/crops/plot/:plot_id")
  *                          note_count:
  *                            type: integer
  *                            example: 1
+ *                          image_count:
+ *                            type: integer
+ *                            example: 1
  *                count:
  *                  type: integer
  *                  example: 1
@@ -205,6 +208,9 @@ cropsRouter.route("/crops/subdivision/:subdivision_id")
  *                      - type: object
  *                        properties:
  *                          note_count:
+ *                            type: integer
+ *                            example: 1
+ *                          image_count:
  *                            type: integer
  *                            example: 1
  *                count:


### PR DESCRIPTION
### Summary

- Extended SQL query in `selectCropsByPlotId` and `selectCropsBySubdivisionId` to return an image count for each crop
- Updated test case and JSDoc annotations accordingly