### PR TITLE
Crop types

### DIFF
--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -18,7 +18,7 @@ describe("GET /api/auth", () => {
     const auth = await request(app)
       .post("/api/login")
       .send({
-        username: "carrot_king",
+        login: "carrot_king",
         password: "carrots123",
       })
 

--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -577,6 +577,25 @@ describe("POST /api/crops/plot/:plot_id", () => {
     })
   })
 
+  test("POST:400 Responds with an error when passed an invalid crop category", async () => {
+
+    const newCrop = {
+      name: "Pear",
+      category: "foobar"
+    }
+
+    const { body } = await request(app)
+      .post("/api/crops/plot/1")
+      .send(newCrop)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Bad Request",
+      details: "Invalid crop category"
+    })
+  })
+
   test("POST:400 Responds with an error message when the plot_id is not a positive integer", async () => {
 
     const newCrop = {
@@ -1143,6 +1162,25 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
     expect(body).toMatchObject<StatusResponse>({
       message: "Bad Request",
       details: "Not null violation"
+    })
+  })
+
+  test("POST:400 Responds with an error when passed an invalid crop category", async () => {
+
+    const newCrop = {
+      name: "Pear",
+      category: "foobar"
+    }
+
+    const { body } = await request(app)
+      .post("/api/crops/subdivision/1")
+      .send(newCrop)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Bad Request",
+      details: "Invalid crop category"
     })
   })
 

--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -87,7 +87,7 @@ describe("GET /api/crops/plot/:plot_id", () => {
   test("GET:400 Responds with an error message when the plot_id is not a positive integer", async () => {
 
     const { body } = await request(app)
-      .get("/api/crops/plot/example")
+      .get("/api/crops/plot/foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(400)
 
@@ -194,7 +194,7 @@ describe("GET /api/crops/plot/:plot_id?name=", () => {
   test("GET:200 Returns an empty array when the value of name matches no results", async () => {
 
     const { body } = await request(app)
-      .get("/api/crops/plot/1?name=example")
+      .get("/api/crops/plot/1?name=foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
@@ -339,7 +339,7 @@ describe("GET /api/crops/plot/:plot_id?order=", () => {
   test("GET:404 Responds with an error when passed an invalid order value", async () => {
 
     const { body } = await request(app)
-      .get("/api/crops/plot/1?order=example")
+      .get("/api/crops/plot/1?order=")
       .set("Authorization", `Bearer ${token}`)
       .expect(404)
 
@@ -589,7 +589,7 @@ describe("POST /api/crops/plot/:plot_id", () => {
     }
 
     const { body } = await request(app)
-      .post("/api/crops/plot/example")
+      .post("/api/crops/plot/foobar")
       .send(newCrop)
       .set("Authorization", `Bearer ${token}`)
       .expect(400)
@@ -690,7 +690,7 @@ describe("GET /api/crops/subdivision/:subdivision_id", () => {
   test("GET:400 Responds with an error message when the subdivision_id is not a positive integer", async () => {
 
     const { body } = await request(app)
-      .get("/api/crops/subdivision/example")
+      .get("/api/crops/subdivision/foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(400)
 
@@ -779,7 +779,7 @@ describe("GET /api/crops/subdivision/:subdivision_id?name=", () => {
   test("GET:200 Returns an empty array when the value of name matches no results", async () => {
 
     const { body } = await request(app)
-      .get("/api/crops/subdivision/1?name=example")
+      .get("/api/crops/subdivision/1?name=foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
@@ -924,7 +924,7 @@ describe("GET /api/crops/subdivision/:subdivision_id?order=", () => {
   test("GET:404 Responds with an error when passed an invalid order value", async () => {
 
     const { body } = await request(app)
-      .get("/api/crops/subdivision/1?order=example")
+      .get("/api/crops/subdivision/1?order=foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(404)
 
@@ -1160,7 +1160,7 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
     }
 
     const { body } = await request(app)
-      .post("/api/crops/subdivision/example")
+      .post("/api/crops/subdivision/foobar")
       .send(newCrop)
       .set("Authorization", `Bearer ${token}`)
       .expect(400)

--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -59,6 +59,7 @@ describe("GET /api/crops/plot/:plot_id", () => {
         name: expect.any(String),
         variety: expect.toBeOneOf([expect.any(String), null]),
         quantity: expect.toBeOneOf([expect.any(Number), null]),
+        category: expect.any(String),
         date_planted: expect.toBeOneOf([expect.stringMatching(regex), null]),
         harvest_date: expect.toBeOneOf([expect.stringMatching(regex), null]),
         subdivision_name: expect.toBeOneOf([expect.any(String), null]),
@@ -470,6 +471,7 @@ describe("POST /api/crops/plot/:plot_id", () => {
     const newCrop = {
       name: "Pear",
       variety: "Conference",
+      category: "Fruits",
       quantity: 1,
       date_planted: new Date("2024-07-21"),
       harvest_date: new Date("2024-09-30")
@@ -487,6 +489,7 @@ describe("POST /api/crops/plot/:plot_id", () => {
       subdivision_id: null,
       name: "Pear",
       variety: "Conference",
+      category: "Fruits",
       quantity: 1,
       date_planted: expect.toBeOneOf([expect.stringMatching(regex), null]),
       harvest_date: expect.toBeOneOf([expect.stringMatching(regex), null])
@@ -496,7 +499,8 @@ describe("POST /api/crops/plot/:plot_id", () => {
   test("POST:201 Assigns a null value to 'subdivision_id', 'variety', 'quantity', 'date_planted', and 'harvest_date' when no value is provided", async () => {
 
     const newCrop = {
-      name: "Pear"
+      name: "Pear",
+      category: "Fruits"
     }
 
     const { body } = await request(app)
@@ -511,6 +515,7 @@ describe("POST /api/crops/plot/:plot_id", () => {
       subdivision_id: null,
       name: "Pear",
       variety: null,
+      category: "Fruits",
       quantity: null,
       date_planted: null,
       harvest_date: null
@@ -521,6 +526,7 @@ describe("POST /api/crops/plot/:plot_id", () => {
 
     const newCrop = {
       name: "Pear",
+      category: "Fruits",
       price: 100
     }
 
@@ -537,6 +543,7 @@ describe("POST /api/crops/plot/:plot_id", () => {
 
     const newCrop = {
       name: "Pear",
+      category: "Fruits",
       quantity: "one",
     }
 
@@ -554,7 +561,9 @@ describe("POST /api/crops/plot/:plot_id", () => {
 
   test("POST:400 Responds with an error when a required property is missing from the request body", async () => {
 
-    const newCrop = {}
+    const newCrop = {
+      category: "Fruits"
+    }
 
     const { body } = await request(app)
       .post("/api/crops/plot/1")
@@ -571,7 +580,8 @@ describe("POST /api/crops/plot/:plot_id", () => {
   test("POST:400 Responds with an error message when the plot_id is not a positive integer", async () => {
 
     const newCrop = {
-      name: "Pear"
+      name: "Pear",
+      category: "Fruits"
     }
 
     const { body } = await request(app)
@@ -589,7 +599,8 @@ describe("POST /api/crops/plot/:plot_id", () => {
   test("POST:403 Responds with a warning when the authenticated user attempts to add a crop for another user", async () => {
 
     const newCrop = {
-      name: "Pear"
+      name: "Pear",
+      category: "Fruits"
     }
 
     const { body } = await request(app)
@@ -607,7 +618,8 @@ describe("POST /api/crops/plot/:plot_id", () => {
   test("POST:404 Responds with an error message when the plot_id does not exist", async () => {
 
     const newCrop = {
-      name: "Pear"
+      name: "Pear",
+      category: "Fruits"
     }
 
     const { body } = await request(app)
@@ -648,6 +660,7 @@ describe("GET /api/crops/subdivision/:subdivision_id", () => {
         subdivision_id: expect.toBeOneOf([expect.any(Number), null]),
         name: expect.any(String),
         variety: expect.toBeOneOf([expect.any(String), null]),
+        category: expect.any(String),
         quantity: expect.toBeOneOf([expect.any(Number), null]),
         date_planted: expect.toBeOneOf([expect.stringMatching(regex), null]),
         harvest_date: expect.toBeOneOf([expect.stringMatching(regex), null]),
@@ -1027,6 +1040,7 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
     const newCrop = {
       name: "Pear",
       variety: "Conference",
+      category: "Fruits",
       quantity: 1,
       date_planted: new Date("2024-07-21"),
       harvest_date: new Date("2024-09-30")
@@ -1044,6 +1058,7 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
       subdivision_id: 1,
       name: "Pear",
       variety: "Conference",
+      category: "Fruits",
       quantity: 1,
       date_planted: expect.toBeOneOf([expect.stringMatching(regex), null]),
       harvest_date: expect.toBeOneOf([expect.stringMatching(regex), null])
@@ -1053,7 +1068,8 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
   test("POST:201 Assigns a null value to 'variety', 'quantity', 'date_planted', and 'harvest_date' when no value is provided", async () => {
 
     const newCrop = {
-      name: "Pear"
+      name: "Pear",
+      category: "Fruits"
     }
 
     const { body } = await request(app)
@@ -1068,6 +1084,7 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
       subdivision_id: 1,
       name: "Pear",
       variety: null,
+      category: "Fruits",
       quantity: null,
       date_planted: null,
       harvest_date: null
@@ -1078,6 +1095,7 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
 
     const newCrop = {
       name: "Pear",
+      category: "Fruits",
       price: 100
     }
 
@@ -1094,6 +1112,7 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
 
     const newCrop = {
       name: "Pear",
+      category: "Fruits",
       quantity: "one",
     }
 
@@ -1111,7 +1130,9 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
 
   test("POST:400 Responds with an error when a required property is missing from the request body", async () => {
 
-    const newCrop = {}
+    const newCrop = {
+      category: "Fruits"
+    }
 
     const { body } = await request(app)
       .post("/api/crops/subdivision/1")
@@ -1128,7 +1149,8 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
   test("POST:400 Responds with an error message when the plot_id is not a positive integer", async () => {
 
     const newCrop = {
-      name: "Pear"
+      name: "Pear",
+      category: "Fruits"
     }
 
     const { body } = await request(app)
@@ -1146,7 +1168,8 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
   test("POST:403 Responds with a warning when the authenticated user attempts to add a crop for another user", async () => {
 
     const newCrop = {
-      name: "Pear"
+      name: "Pear",
+      category: "Fruits"
     }
 
     const { body } = await request(app)
@@ -1164,7 +1187,8 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
   test("POST:404 Responds with an error message when the subdivision does not exist", async () => {
 
     const newCrop = {
-      name: "Pear"
+      name: "Pear",
+      category: "Fruits"
     }
 
     const { body } = await request(app)

--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -163,24 +163,10 @@ describe("GET /api/crops/plot/:plot_id", () => {
 
 describe("GET /api/crops/plot/:plot_id?name=", () => {
 
-  test("GET:200 Responds with an array of crop objects filtered by name", async () => {
+  test("GET:200 Responds with an array of crop objects filtered case-insensitively by name", async () => {
 
     const { body } = await request(app)
       .get("/api/crops/plot/1?name=ca")
-      .set("Authorization", `Bearer ${token}`)
-      .expect(200)
-
-    for (const crop of body.crops) {
-      expect(crop.name).toMatch(/ca/i)
-    }
-
-    expect(body.count).toBe(3)
-  })
-
-  test("GET:200 Filtered results are case-insensitive", async () => {
-
-    const { body } = await request(app)
-      .get("/api/crops/plot/1?name=CA")
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
@@ -274,7 +260,7 @@ describe("GET /api/crops/plot/:plot_id?sort=", () => {
   test("GET:404 Responds with an error when passed an invalid sort value", async () => {
 
     const { body } = await request(app)
-      .get("/api/crops/plot/1?sort=variety")
+      .get("/api/crops/plot/1?sort=foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(404)
 
@@ -339,7 +325,7 @@ describe("GET /api/crops/plot/:plot_id?order=", () => {
   test("GET:404 Responds with an error when passed an invalid order value", async () => {
 
     const { body } = await request(app)
-      .get("/api/crops/plot/1?order=")
+      .get("/api/crops/plot/1?order=foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(404)
 
@@ -482,8 +468,8 @@ describe("POST /api/crops/plot/:plot_id", () => {
   test("POST:201 Responds with a new crop object, assigning plot_id and subdivision_id (null) automatically", async () => {
 
     const newCrop = {
-      name: "pear",
-      variety: "conference",
+      name: "Pear",
+      variety: "Conference",
       quantity: 1,
       date_planted: new Date("2024-07-21"),
       harvest_date: new Date("2024-09-30")
@@ -499,8 +485,8 @@ describe("POST /api/crops/plot/:plot_id", () => {
       crop_id: 7,
       plot_id: 1,
       subdivision_id: null,
-      name: "pear",
-      variety: "conference",
+      name: "Pear",
+      variety: "Conference",
       quantity: 1,
       date_planted: expect.toBeOneOf([expect.stringMatching(regex), null]),
       harvest_date: expect.toBeOneOf([expect.stringMatching(regex), null])
@@ -510,7 +496,7 @@ describe("POST /api/crops/plot/:plot_id", () => {
   test("POST:201 Assigns a null value to 'subdivision_id', 'variety', 'quantity', 'date_planted', and 'harvest_date' when no value is provided", async () => {
 
     const newCrop = {
-      name: "pear"
+      name: "Pear"
     }
 
     const { body } = await request(app)
@@ -523,7 +509,7 @@ describe("POST /api/crops/plot/:plot_id", () => {
       crop_id: 7,
       plot_id: 1,
       subdivision_id: null,
-      name: "pear",
+      name: "Pear",
       variety: null,
       quantity: null,
       date_planted: null,
@@ -534,7 +520,7 @@ describe("POST /api/crops/plot/:plot_id", () => {
   test("POST:201 Ignores any unnecessary properties on the object", async () => {
 
     const newCrop = {
-      name: "pear",
+      name: "Pear",
       price: 100
     }
 
@@ -550,7 +536,7 @@ describe("POST /api/crops/plot/:plot_id", () => {
   test("POST:400 Responds with an error when passed a property with an invalid data type", async () => {
 
     const newCrop = {
-      name: "pear",
+      name: "Pear",
       quantity: "one",
     }
 
@@ -585,7 +571,7 @@ describe("POST /api/crops/plot/:plot_id", () => {
   test("POST:400 Responds with an error message when the plot_id is not a positive integer", async () => {
 
     const newCrop = {
-      name: "pear"
+      name: "Pear"
     }
 
     const { body } = await request(app)
@@ -603,7 +589,7 @@ describe("POST /api/crops/plot/:plot_id", () => {
   test("POST:403 Responds with a warning when the authenticated user attempts to add a crop for another user", async () => {
 
     const newCrop = {
-      name: "pear"
+      name: "Pear"
     }
 
     const { body } = await request(app)
@@ -621,7 +607,7 @@ describe("POST /api/crops/plot/:plot_id", () => {
   test("POST:404 Responds with an error message when the plot_id does not exist", async () => {
 
     const newCrop = {
-      name: "pear"
+      name: "Pear"
     }
 
     const { body } = await request(app)
@@ -748,24 +734,10 @@ describe("GET /api/crops/subdivision/:subdivision_id", () => {
 
 describe("GET /api/crops/subdivision/:subdivision_id?name=", () => {
 
-  test("GET:200 Responds with an array of crop objects filtered by name", async () => {
+  test("GET:200 Responds with an array of crop objects filtered case-insensitively by name", async () => {
 
     const { body } = await request(app)
       .get("/api/crops/subdivision/1?name=car")
-      .set("Authorization", `Bearer ${token}`)
-      .expect(200)
-
-    for (const crop of body.crops) {
-      expect(crop.name).toMatch(/car/i)
-    }
-
-    expect(body.count).toBe(1)
-  })
-
-  test("GET:200 Filtered results are case-insensitive", async () => {
-
-    const { body } = await request(app)
-      .get("/api/crops/subdivision/1?name=CAR")
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
@@ -859,7 +831,7 @@ describe("GET /api/crops/subdivision/:subdivision_id?sort=", () => {
   test("GET:404 Responds with an error when passed an invalid sort value", async () => {
 
     const { body } = await request(app)
-      .get("/api/crops/subdivision/1?sort=variety")
+      .get("/api/crops/subdivision/1?sort=foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(404)
 
@@ -1053,8 +1025,8 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
   test("POST:201 Responds with a new crop object, assigning plot_id and subdivision_id automatically", async () => {
 
     const newCrop = {
-      name: "pear",
-      variety: "conference",
+      name: "Pear",
+      variety: "Conference",
       quantity: 1,
       date_planted: new Date("2024-07-21"),
       harvest_date: new Date("2024-09-30")
@@ -1070,8 +1042,8 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
       crop_id: 7,
       plot_id: 1,
       subdivision_id: 1,
-      name: "pear",
-      variety: "conference",
+      name: "Pear",
+      variety: "Conference",
       quantity: 1,
       date_planted: expect.toBeOneOf([expect.stringMatching(regex), null]),
       harvest_date: expect.toBeOneOf([expect.stringMatching(regex), null])
@@ -1081,7 +1053,7 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
   test("POST:201 Assigns a null value to 'variety', 'quantity', 'date_planted', and 'harvest_date' when no value is provided", async () => {
 
     const newCrop = {
-      name: "pear"
+      name: "Pear"
     }
 
     const { body } = await request(app)
@@ -1094,7 +1066,7 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
       crop_id: 7,
       plot_id: 1,
       subdivision_id: 1,
-      name: "pear",
+      name: "Pear",
       variety: null,
       quantity: null,
       date_planted: null,
@@ -1105,7 +1077,7 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
   test("POST:201 Ignores any unnecessary properties on the object", async () => {
 
     const newCrop = {
-      name: "pear",
+      name: "Pear",
       price: 100
     }
 
@@ -1121,7 +1093,7 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
   test("POST:400 Responds with an error when passed a property with an invalid data type", async () => {
 
     const newCrop = {
-      name: "pear",
+      name: "Pear",
       quantity: "one",
     }
 
@@ -1156,7 +1128,7 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
   test("POST:400 Responds with an error message when the plot_id is not a positive integer", async () => {
 
     const newCrop = {
-      name: "pear"
+      name: "Pear"
     }
 
     const { body } = await request(app)
@@ -1174,7 +1146,7 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
   test("POST:403 Responds with a warning when the authenticated user attempts to add a crop for another user", async () => {
 
     const newCrop = {
-      name: "pear"
+      name: "Pear"
     }
 
     const { body } = await request(app)
@@ -1192,7 +1164,7 @@ describe("POST /api/crops/subdivision/:subdivision_id", () => {
   test("POST:404 Responds with an error message when the subdivision does not exist", async () => {
 
     const newCrop = {
-      name: "pear"
+      name: "Pear"
     }
 
     const { body } = await request(app)

--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -21,7 +21,7 @@ beforeEach(async () => {
   const auth = await request(app)
     .post("/api/login")
     .send({
-      username: "carrot_king",
+      login: "carrot_king",
       password: "carrots123",
     })
 

--- a/src/__tests__/login.test.ts
+++ b/src/__tests__/login.test.ts
@@ -13,10 +13,25 @@ afterAll(() => db.end())
 
 describe("POST /api/login", () => {
 
-  test("POST:200 Responds with a JWT token when the credentials are valid", async () => {
+  test("POST:200 Responds with a JWT token when passed a valid username and password", async () => {
 
     const user = {
-      username: "carrot_king",
+      login: "carrot_king",
+      password: "carrots123"
+    }
+
+    const { body } = await request(app)
+      .post("/api/login")
+      .send(user)
+      .expect(200)
+
+    expect(body.token).toMatch(/[\w-]{2,}\.[\w-]{2,}\.[\w-]{2,}/)
+  })
+
+  test("POST:200 Responds with a JWT token when passed a valid email and password", async () => {
+
+    const user = {
+      login: "john.smith@example.com",
       password: "carrots123"
     }
 
@@ -31,7 +46,7 @@ describe("POST /api/login", () => {
   test("POST:401 Responds with an error message when the password is incorrect", async () => {
 
     const user = {
-      username: "carrot_king",
+      login: "carrot_king",
       password: "apples123"
     }
 
@@ -46,10 +61,10 @@ describe("POST /api/login", () => {
     })
   })
 
-  test("POST:404 Responds with an error message when the username is not found", async () => {
+  test("POST:404 Responds with an error message when the username or email is not found", async () => {
 
     const user = {
-      username: "mango_man",
+      login: "mango_man",
       password: "carrots123"
     }
 
@@ -60,7 +75,7 @@ describe("POST /api/login", () => {
 
     expect(body).toMatchObject<StatusResponse>({
       message: "Not Found",
-      details: "Username could not be found"
+      details: "Username or email could not be found"
     })
   })
 })

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -154,7 +154,7 @@ describe("GET /api/plots/user/:owner_id", () => {
 
 describe("GET /api/plots/user/:owner_id?type=", () => {
 
-  test("GET:200 Responds with an array of plot objects filtered by type", async () => {
+  test("GET:200 Responds with an array of plot objects filtered case-insensitively by type", async () => {
 
     const { body } = await request(app)
       .get("/api/plots/user/1?type=allotment")
@@ -164,7 +164,7 @@ describe("GET /api/plots/user/:owner_id?type=", () => {
     expect(body.plots).toHaveLength(2)
 
     for (const plot of body.plots) {
-      expect(plot.type).toBe("allotment")
+      expect(plot.type).toBe("Allotment")
     }
 
     expect(body.count).toBe(2)
@@ -241,7 +241,7 @@ describe("GET /api/plots/user/:owner_id?type=&name=", () => {
       .expect(200)
 
     for (const plot of body.plots) {
-      expect(plot.type).toBe("allotment")
+      expect(plot.type).toBe("Allotment")
       expect(plot.name).toMatch(/new/i)
     }
 
@@ -420,7 +420,7 @@ describe("POST /api/plots/user/:owner_id", () => {
 
     const newPlot = {
       name: "John's Field",
-      type: "field",
+      type: "Field",
       description: "A large field",
       location: "Wildwood",
       area: 3000
@@ -436,7 +436,7 @@ describe("POST /api/plots/user/:owner_id", () => {
       plot_id: 5,
       owner_id: 1,
       name: "John's Field",
-      type: "field",
+      type: "Field",
       description: "A large field",
       location: "Wildwood",
       area: 3000,
@@ -448,7 +448,7 @@ describe("POST /api/plots/user/:owner_id", () => {
 
     const newPlot = {
       name: "John's Field",
-      type: "field",
+      type: "Field",
       description: "A large field",
       location: "Wildwood"
     }
@@ -466,7 +466,7 @@ describe("POST /api/plots/user/:owner_id", () => {
 
     const newPlot = {
       name: "John's Field",
-      type: "field",
+      type: "Field",
       description: "A large field",
       location: "Wildwood",
       area: 3000,
@@ -486,7 +486,7 @@ describe("POST /api/plots/user/:owner_id", () => {
 
     const newPlot = {
       name: "John's Field",
-      type: "field",
+      type: "Field",
       description: "A large field",
       location: "Wildwood",
       area: "three thousand metres"
@@ -507,7 +507,7 @@ describe("POST /api/plots/user/:owner_id", () => {
   test("POST:400 Responds with an error when a required property is missing from the request body", async () => {
 
     const newPlot = {
-      type: "field",
+      type: "Field",
       description: "A large field",
       location: "Wildwood",
       area: 3000
@@ -529,7 +529,7 @@ describe("POST /api/plots/user/:owner_id", () => {
 
     const newPlot = {
       name: "John's Field",
-      type: "garage",
+      type: "foobar",
       description: "A large field",
       location: "Wildwood",
       area: 3000
@@ -551,7 +551,7 @@ describe("POST /api/plots/user/:owner_id", () => {
 
     const newPlot = {
       name: "John's Field",
-      type: "field",
+      type: "Field",
       description: "A large field",
       location: "Wildwood",
       area: 3000
@@ -573,7 +573,7 @@ describe("POST /api/plots/user/:owner_id", () => {
 
     const newPlot = {
       name: "John's Field",
-      type: "field",
+      type: "Field",
       description: "A large field",
       location: "Wildwood",
       area: 3000
@@ -595,7 +595,7 @@ describe("POST /api/plots/user/:owner_id", () => {
 
     const newPlot = {
       name: "John's Field",
-      type: "field",
+      type: "Field",
       description: "A large field",
       location: "Wildwood",
       area: 3000
@@ -617,7 +617,7 @@ describe("POST /api/plots/user/:owner_id", () => {
 
     const newPlot = {
       name: "John's Garden",
-      type: "garden",
+      type: "Garden",
       description: "The garden at the new house",
       location: "Applebury",
       area: 120
@@ -743,7 +743,7 @@ describe("GET /api/plots/:plot_id", () => {
       plot_id: 1,
       owner_id: 1,
       name: "John's Garden",
-      type: "garden",
+      type: "Garden",
       description: "A vegetable garden",
       location: "Farmville",
       area: 100,
@@ -803,7 +803,7 @@ describe("PATCH /api/plots/:plot_id", () => {
 
     const newDetails = {
       name: "John's Homestead",
-      type: "homestead",
+      type: "Homestead",
       description: "A homestead",
       location: "Farmville",
       area: 1200
@@ -819,7 +819,7 @@ describe("PATCH /api/plots/:plot_id", () => {
       plot_id: 1,
       owner_id: 1,
       name: "John's Homestead",
-      type: "homestead",
+      type: "Homestead",
       description: "A homestead",
       location: "Farmville",
       area: 1200,
@@ -831,7 +831,7 @@ describe("PATCH /api/plots/:plot_id", () => {
 
     const newDetails = {
       name: "John's Garden",
-      type: "garden",
+      type: "Garden",
       description: "A new description",
       location: "234, Apricot Avenue, Farmville",
       area: 180
@@ -847,7 +847,7 @@ describe("PATCH /api/plots/:plot_id", () => {
       plot_id: 1,
       owner_id: 1,
       name: "John's Garden",
-      type: "garden",
+      type: "Garden",
       description: "A new description",
       location: "234, Apricot Avenue, Farmville",
       area: 180,
@@ -858,7 +858,7 @@ describe("PATCH /api/plots/:plot_id", () => {
   test("PATCH:400 Responds with an error when a property is missing from the request body", async () => {
 
     const newDetails = {
-      type: "homestead",
+      type: "Homestead",
       description: "A homestead",
       location: "Farmville",
       area: 1200
@@ -880,7 +880,7 @@ describe("PATCH /api/plots/:plot_id", () => {
 
     const newDetails = {
       name: "John's Homestead",
-      type: "homestead",
+      type: "Homestead",
       description: "A homestead",
       location: "Farmville",
       area: "ten metres"
@@ -902,7 +902,7 @@ describe("PATCH /api/plots/:plot_id", () => {
 
     const newDetails = {
       name: "John's Homestead",
-      type: "garage",
+      type: "Garage",
       description: "A homestead",
       location: "Farmville",
       area: 1200
@@ -924,7 +924,7 @@ describe("PATCH /api/plots/:plot_id", () => {
 
     const newDetails = {
       name: "John's Homestead",
-      type: "homestead",
+      type: "Homestead",
       description: "A homestead",
       location: "Farmville",
       area: 1200
@@ -946,7 +946,7 @@ describe("PATCH /api/plots/:plot_id", () => {
 
     const newDetails = {
       name: "John's Homestead",
-      type: "homestead",
+      type: "Homestead",
       description: "A homestead",
       location: "Farmville",
       area: 1200
@@ -968,7 +968,7 @@ describe("PATCH /api/plots/:plot_id", () => {
 
     const newDetails = {
       name: "John's Homestead",
-      type: "homestead",
+      type: "Homestead",
       description: "A homestead",
       location: "Farmville",
       area: 1200
@@ -990,7 +990,7 @@ describe("PATCH /api/plots/:plot_id", () => {
 
     const newDetails = {
       name: "John's Allotment",
-      type: "homestead",
+      type: "Homestead",
       description: "A homestead",
       location: "Farmville",
       area: 1200
@@ -1109,14 +1109,14 @@ describe("PATCH /api/plots/:plot_id/pin", () => {
 
     const fourthPlot = {
       name: "John's Orchard",
-      type: "orchard",
+      type: "Orchard",
       description: "An orchard",
       location: "Farmville"
     }
 
     const fifthPlot = {
       name: "John's New Orchard",
-      type: "orchard",
+      type: "Orchard",
       description: "A new orchard",
       location: "Farmville",
     }

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -96,7 +96,7 @@ describe("GET /api/plots/user/:owner_id", () => {
   test("GET:400 Responds with an error message when the owner_id is not a positive integer", async () => {
 
     const { body } = await request(app)
-      .get("/api/plots/user/example")
+      .get("/api/plots/user/foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(400)
 
@@ -218,7 +218,7 @@ describe("GET /api/plots/user/:owner_id?name=", () => {
   test("GET:200 Returns an empty array when the value of name matches no results", async () => {
 
     const { body } = await request(app)
-      .get("/api/plots/user/1?name=example")
+      .get("/api/plots/user/1?name=foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
@@ -273,7 +273,7 @@ describe("GET /api/plots/user/:owner_id?sort=", () => {
   test("GET:404 Responds with an error when passed an invalid sort value", async () => {
 
     const { body } = await request(app)
-      .get("/api/plots/user/1?sort=example")
+      .get("/api/plots/user/1?sort=foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(404)
 
@@ -290,7 +290,7 @@ describe("GET /api/plots/user/:owner_id?order=", () => {
   test("GET:404 Responds with an error when passed an invalid order value", async () => {
 
     const { body } = await request(app)
-      .get("/api/plots/user/1?order=example")
+      .get("/api/plots/user/1?order=foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(404)
 
@@ -558,7 +558,7 @@ describe("POST /api/plots/user/:owner_id", () => {
     }
 
     const { body } = await request(app)
-      .post("/api/plots/user/example")
+      .post("/api/plots/user/foobar")
       .send(newPlot)
       .set("Authorization", `Bearer ${token}`)
       .expect(400)
@@ -692,7 +692,7 @@ describe("GET /api/plots/user/:owner_id/pinned", () => {
   test("GET:400 Responds with an error message when the owner_id is not a positive integer", async () => {
 
     const { body } = await request(app)
-      .get("/api/plots/user/example/pinned")
+      .get("/api/plots/user/foobar/pinned")
       .set("Authorization", `Bearer ${token}`)
       .expect(400)
 
@@ -759,7 +759,7 @@ describe("GET /api/plots/:plot_id", () => {
   test("GET:400 Responds with an error message when the plot_id is not a positive integer", async () => {
 
     const { body } = await request(app)
-      .get("/api/plots/example")
+      .get("/api/plots/foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(400)
 
@@ -931,7 +931,7 @@ describe("PATCH /api/plots/:plot_id", () => {
     }
 
     const { body } = await request(app)
-      .patch("/api/plots/example")
+      .patch("/api/plots/foobar")
       .send(newDetails)
       .set("Authorization", `Bearer ${token}`)
       .expect(400)
@@ -1033,7 +1033,7 @@ describe("DELETE /api/plots/:plot_id", () => {
   test("DELETE:400 Responds with an error message when the plot_id is not a positive integer", async () => {
 
     const { body } = await request(app)
-      .delete("/api/plots/example")
+      .delete("/api/plots/foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(400)
 
@@ -1187,7 +1187,7 @@ describe("PATCH /api/plots/:plot_id/pin", () => {
     const toggle = { bool: true }
 
     const { body } = await request(app)
-      .patch("/api/plots/example/pin")
+      .patch("/api/plots/foobar/pin")
       .send(toggle)
       .set("Authorization", `Bearer ${token}`)
       .expect(400)

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -902,7 +902,7 @@ describe("PATCH /api/plots/:plot_id", () => {
 
     const newDetails = {
       name: "John's Homestead",
-      type: "Garage",
+      type: "foobar",
       description: "A homestead",
       location: "Farmville",
       area: 1200

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -19,7 +19,7 @@ beforeEach(async () => {
   const auth = await request(app)
     .post("/api/login")
     .send({
-      username: "carrot_king",
+      login: "carrot_king",
       password: "carrots123",
     })
 
@@ -75,7 +75,7 @@ describe("GET /api/plots/user/:owner_id", () => {
     const auth = await request(app)
       .post("/api/login")
       .send({
-        username: "quince_queen",
+        login: "quince_queen",
         password: "quince123",
       })
 
@@ -673,7 +673,7 @@ describe("GET /api/plots/user/:owner_id/pinned", () => {
     const auth = await request(app)
       .post("/api/login")
       .send({
-        username: "peach_princess",
+        login: "peach_princess",
         password: "peaches123",
       })
 

--- a/src/__tests__/subdivisions.test.ts
+++ b/src/__tests__/subdivisions.test.ts
@@ -160,7 +160,7 @@ describe("GET /api/subdivisions/plot/:plot_id", () => {
 
 describe("GET /api/subdivisions/plot/:plot_id?type=", () => {
 
-  test("GET:200 Responds with an array of subdivision objects filtered by type", async () => {
+  test("GET:200 Responds with an array of subdivision objects filtered case-insensitively by type", async () => {
 
     const { body } = await request(app)
       .get("/api/subdivisions/plot/1?type=bed")
@@ -170,7 +170,7 @@ describe("GET /api/subdivisions/plot/:plot_id?type=", () => {
     expect(body.subdivisions).toHaveLength(2)
 
     for (const subdivision of body.subdivisions) {
-      expect(subdivision.type).toBe("bed")
+      expect(subdivision.type).toBe("Bed")
     }
 
     expect(body.count).toBe(2)
@@ -247,7 +247,7 @@ describe("GET /api/subdivisions/plot/:plot_id?type=&name=", () => {
       .expect(200)
 
     for (const subdivision of body.subdivisions) {
-      expect(subdivision.type).toBe("bed")
+      expect(subdivision.type).toBe("Bed")
       expect(subdivision.name).toMatch(/onion/i)
     }
 
@@ -426,7 +426,7 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
 
     const newSubdivision = {
       name: "Wildflowers",
-      type: "flowerbed",
+      type: "Flowerbed",
       description: "Foxgloves and bluebells",
       area: 2
     }
@@ -441,7 +441,7 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
       subdivision_id: 5,
       plot_id: 1,
       name: "Wildflowers",
-      type: "flowerbed",
+      type: "Flowerbed",
       description: "Foxgloves and bluebells",
       area: 2
     })
@@ -451,7 +451,7 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
 
     const newSubdivision = {
       name: "Wildflowers",
-      type: "flowerbed",
+      type: "Flowerbed",
       description: "Foxgloves and bluebells"
     }
 
@@ -468,7 +468,7 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
 
     const newSubdivision = {
       name: "Wildflowers",
-      type: "flowerbed",
+      type: "Flowerbed",
       description: "Foxgloves and bluebells",
       area: 2,
       price: 100
@@ -487,7 +487,7 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
 
     const newSubdivision = {
       name: "Wildflowers",
-      type: "flowerbed",
+      type: "Flowerbed",
       description: "Foxgloves and bluebells",
       area: "two metres squared"
     }
@@ -507,7 +507,7 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
   test("POST:400 Responds with an error when a required property is missing from the request body", async () => {
 
     const newSubdivision = {
-      type: "flowerbed",
+      type: "Flowerbed",
       description: "Foxgloves and bluebells",
       area: 2
     }
@@ -528,7 +528,7 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
 
     const newSubdivision = {
       name: "Wildflowers",
-      type: "garage",
+      type: "foobar",
       description: "Foxgloves and bluebells",
       area: 2
     }
@@ -549,7 +549,7 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
 
     const newSubdivision = {
       name: "Wildflowers",
-      type: "flowerbed",
+      type: "Flowerbed",
       description: "Foxgloves and bluebells",
       area: 2
     }
@@ -570,7 +570,7 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
 
     const newSubdivision = {
       name: "Wildflowers",
-      type: "flowerbed",
+      type: "Flowerbed",
       description: "Foxgloves and bluebells",
       area: 2
     }
@@ -591,7 +591,7 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
 
     const newSubdivision = {
       name: "Wildflowers",
-      type: "flowerbed",
+      type: "Flowerbed",
       description: "Foxgloves and bluebells",
       area: 2
     }
@@ -612,7 +612,7 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
 
     const newSubdivision = {
       name: "Onion Bed",
-      type: "flowerbed",
+      type: "Flowerbed",
       description: "Foxgloves and bluebells",
       area: 2
     }
@@ -644,7 +644,7 @@ describe("GET /api/subdivisions/:subdivision_id", () => {
       subdivision_id: 1,
       plot_id: 1,
       name: "Root Vegetable Bed",
-      type: "bed",
+      type: "Bed",
       description: "Carrots, beetroots, and parsnips",
       area: 10,
       plot_name: "John's Garden",
@@ -702,7 +702,7 @@ describe("PATCH /api/subdivisions/:subdivision_id", () => {
 
     const newDetails = {
       name: "Root Vegetable Patch",
-      type: "vegetable patch",
+      type: "Vegetable patch",
       description: "Turnips and radishes",
       area: 20
     }
@@ -717,7 +717,7 @@ describe("PATCH /api/subdivisions/:subdivision_id", () => {
       subdivision_id: 1,
       plot_id: 1,
       name: 'Root Vegetable Patch',
-      type: 'vegetable patch',
+      type: 'Vegetable patch',
       description: 'Turnips and radishes',
       area: 20
     })
@@ -727,7 +727,7 @@ describe("PATCH /api/subdivisions/:subdivision_id", () => {
 
     const newDetails = {
       name: "Root Vegetable Bed",
-      type: "vegetable patch",
+      type: "Vegetable patch",
       description: "Turnips and radishes",
       area: 20
     }
@@ -742,7 +742,7 @@ describe("PATCH /api/subdivisions/:subdivision_id", () => {
       subdivision_id: 1,
       plot_id: 1,
       name: 'Root Vegetable Bed',
-      type: 'vegetable patch',
+      type: 'Vegetable patch',
       description: 'Turnips and radishes',
       area: 20
     })
@@ -751,7 +751,7 @@ describe("PATCH /api/subdivisions/:subdivision_id", () => {
   test("PATCH:400 Responds with an error when a property is missing from the request body", async () => {
 
     const newDetails = {
-      type: "vegetable patch",
+      type: "Vegetable patch",
       description: "Turnips and radishes",
       area: 20
     }
@@ -772,7 +772,7 @@ describe("PATCH /api/subdivisions/:subdivision_id", () => {
 
     const newDetails = {
       name: "Root Vegetable Patch",
-      type: "vegetable patch",
+      type: "Vegetable patch",
       description: "Turnips and radishes",
       area: "twenty"
     }
@@ -793,7 +793,7 @@ describe("PATCH /api/subdivisions/:subdivision_id", () => {
 
     const newDetails = {
       name: "Root Vegetable Patch",
-      type: "garage",
+      type: "foobar",
       description: "Turnips and radishes",
       area: 20
     }
@@ -814,7 +814,7 @@ describe("PATCH /api/subdivisions/:subdivision_id", () => {
 
     const newDetails = {
       name: "Root Vegetable Patch",
-      type: "vegetable patch",
+      type: "Vegetable patch",
       description: "Turnips and radishes",
       area: 20
     }
@@ -835,7 +835,7 @@ describe("PATCH /api/subdivisions/:subdivision_id", () => {
 
     const newDetails = {
       name: "Root Vegetable Patch",
-      type: "vegetable patch",
+      type: "Vegetable patch",
       description: "Turnips and radishes",
       area: 20
     }
@@ -856,7 +856,7 @@ describe("PATCH /api/subdivisions/:subdivision_id", () => {
 
     const newDetails = {
       name: "Root Vegetable Patch",
-      type: "vegetable patch",
+      type: "Vegetable patch",
       description: "Turnips and radishes",
       area: 20
     }
@@ -877,7 +877,7 @@ describe("PATCH /api/subdivisions/:subdivision_id", () => {
 
     const newDetails = {
       name: "Onion Bed",
-      type: "bed",
+      type: "Bed",
       description: "Yellow and white onions",
       area: 20
     }

--- a/src/__tests__/subdivisions.test.ts
+++ b/src/__tests__/subdivisions.test.ts
@@ -84,7 +84,7 @@ describe("GET /api/subdivisions/plot/:plot_id", () => {
   test("GET:400 Responds with an error message when the plot_id is not a positive integer", async () => {
 
     const { body } = await request(app)
-      .get("/api/subdivisions/plot/example")
+      .get("/api/subdivisions/plot/foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(400)
 
@@ -224,7 +224,7 @@ describe("GET /api/subdivisions/plot/:plot_id?name=", () => {
   test("GET:200 Returns an empty array when the value of name matches no results", async () => {
 
     const { body } = await request(app)
-      .get("/api/subdivisions/plot/1?name=example")
+      .get("/api/subdivisions/plot/1?name=foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
@@ -279,7 +279,7 @@ describe("GET /api/subdivisions/plot/:plot_id?sort=", () => {
   test("GET:404 Responds with an error when passed an invalid sort value", async () => {
 
     const { body } = await request(app)
-      .get("/api/subdivisions/plot/1?sort=example")
+      .get("/api/subdivisions/plot/1?sort=foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(404)
 
@@ -296,7 +296,7 @@ describe("GET /api/subdivisions/plot/:plot_id?order=", () => {
   test("GET:404 Responds with an error when passed an invalid order value", async () => {
 
     const { body } = await request(app)
-      .get("/api/subdivisions/plot/1?order=example")
+      .get("/api/subdivisions/plot/1?order=foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(404)
 
@@ -555,7 +555,7 @@ describe("POST /api/subdivisions/plot/:plot_id", () => {
     }
 
     const { body } = await request(app)
-      .post("/api/subdivisions/plot/example")
+      .post("/api/subdivisions/plot/foobar")
       .send(newSubdivision)
       .set("Authorization", `Bearer ${token}`)
       .expect(400)
@@ -658,7 +658,7 @@ describe("GET /api/subdivisions/:subdivision_id", () => {
   test("GET:400 Responds with an error message when the subdivision is not a positive integer", async () => {
 
     const { body } = await request(app)
-      .get("/api/subdivisions/example")
+      .get("/api/subdivisions/foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(400)
 
@@ -820,7 +820,7 @@ describe("PATCH /api/subdivisions/:subdivision_id", () => {
     }
 
     const { body } = await request(app)
-      .patch("/api/subdivisions/example")
+      .patch("/api/subdivisions/foobar")
       .send(newDetails)
       .set("Authorization", `Bearer ${token}`)
       .expect(400)
@@ -919,7 +919,7 @@ describe("DELETE /api/subdivisions/:subdivision_id", () => {
   test("DELETE:400 Responds with an error message when the subdivision_id is not a positive integer", async () => {
 
     const { body } = await request(app)
-      .delete("/api/subdivisions/example")
+      .delete("/api/subdivisions/foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(400)
 

--- a/src/__tests__/subdivisions.test.ts
+++ b/src/__tests__/subdivisions.test.ts
@@ -19,7 +19,7 @@ beforeEach(async () => {
   const auth = await request(app)
     .post("/api/login")
     .send({
-      username: "carrot_king",
+      login: "carrot_king",
       password: "carrots123",
     })
 

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -17,7 +17,7 @@ beforeEach(async () => {
   const auth = await request(app)
     .post("/api/login")
     .send({
-      username: "carrot_king",
+      login: "carrot_king",
       password: "carrots123",
     })
 

--- a/src/__tests__/utils/verification.test.ts
+++ b/src/__tests__/utils/verification.test.ts
@@ -92,7 +92,7 @@ describe("verifyQueryValue", () => {
 
   test("When the query value is not found in the array of valid values, the promise is rejected", () => {
 
-    expect(verifyQueryValue(["foo", "bar"], "example")).rejects.toMatchObject<StatusResponse>({
+    expect(verifyQueryValue(["foo", "bar"], "foobar")).rejects.toMatchObject<StatusResponse>({
       status: 404,
       message: "Not Found",
       details: "No results found for that query"

--- a/src/db/data/development-data/crops/crop-categories.ts
+++ b/src/db/data/development-data/crops/crop-categories.ts
@@ -1,0 +1,26 @@
+export const cropCategoryData: {category: string}[] = [
+  {
+    category: "Fruits"
+  },
+  {
+    category: "Fungi"
+  },
+  {
+    category: "Grains"
+  },
+  {
+    category: "Herbs and spices"
+  },
+  {
+    category: "Legumes"
+  },
+  {
+    category: "Nuts and seeds"
+  },
+  {
+    category: "Ornamental plants"
+  },
+  {
+    category: "Vegetables"
+  }
+]

--- a/src/db/data/development-data/crops/crops.ts
+++ b/src/db/data/development-data/crops/crops.ts
@@ -7,6 +7,7 @@ export const cropData: Crop[] = [
     subdivision_id: 1,
     name: "Thyme",
     variety: null,
+    category: "Herbs and spices",
     quantity: null,
     date_planted: null,
     harvest_date: null
@@ -16,6 +17,7 @@ export const cropData: Crop[] = [
     subdivision_id: 2,
     name: "Potato",
     variety: "Maris Piper",
+    category: "Vegetables",
     quantity: 10,
     date_planted: new Date("2024-07-01"),
     harvest_date: new Date("2034-07-01")
@@ -25,6 +27,7 @@ export const cropData: Crop[] = [
     subdivision_id: 2,
     name: "Cabbage",
     variety: "Savoy",
+    category: "Vegetables",
     quantity: 20,
     date_planted: new Date("2024-06-01"),
     harvest_date: new Date("2025-06-01")

--- a/src/db/data/development-data/development-index.ts
+++ b/src/db/data/development-data/development-index.ts
@@ -8,6 +8,7 @@ import { subdivisionTypeData } from "./subdivisions/valid-subdivision-types"
 import { cropData } from "./crops/crops"
 import { cropNoteData } from "./crops/crop-notes"
 import { cropImageData } from "./crops/crop-images"
+import { cropCategoryData } from "./crops/crop-categories"
 import { issueData } from "./issues/issues"
 import { issueNoteData } from "./issues/issue-notes"
 import { issueImageData } from "./issues/issue-images"
@@ -26,6 +27,7 @@ export default {
   cropData,
   cropNoteData,
   cropImageData,
+  cropCategoryData,
   issueData,
   issueNoteData,
   issueImageData,

--- a/src/db/data/development-data/plots/plots.ts
+++ b/src/db/data/development-data/plots/plots.ts
@@ -5,7 +5,7 @@ export const plotData: Plot[] = [
   {
     owner_id: 1,
     name: "Admin's Field",
-    type: "field",
+    type: "Field",
     description: "The admin's field",
     location: "Example location",
     area: 100,
@@ -14,7 +14,7 @@ export const plotData: Plot[] = [
   {
     owner_id: 1,
     name: "Admin's Allotment",
-    type: "allotment",
+    type: "Allotment",
     description: "The admin's allotment",
     location: "Example location",
     area: null,

--- a/src/db/data/development-data/plots/valid-plot-types.ts
+++ b/src/db/data/development-data/plots/valid-plot-types.ts
@@ -1,17 +1,17 @@
 export const plotTypeData: {type: string}[] = [
   {
-    type: "allotment"
+    type: "Allotment"
   },
   {
-    type: "field"
+    type: "Field"
   },
   {
-    type: "garden"
+    type: "Garden"
   },
   {
-    type: "homestead"
+    type: "Homestead"
   },
   {
-    type: "orchard"
+    type: "Orchard"
   }
 ]

--- a/src/db/data/development-data/subdivisions/subdivisions.ts
+++ b/src/db/data/development-data/subdivisions/subdivisions.ts
@@ -5,14 +5,14 @@ export const subdivisionData: Subdivision[] = [
   {
     plot_id: 1,
     name: "Admin's Herb Garden",
-    type: "herb garden",
+    type: "Herb garden",
     description: "The admin's herb garden",
     area: null
   },
   {
     plot_id: 1,
     name: "Admin's Vegetable Patch",
-    type: "vegetable patch",
+    type: "Vegetable patch",
     description: "The admin's vegetable patch",
     area: 5
   }

--- a/src/db/data/development-data/subdivisions/valid-subdivision-types.ts
+++ b/src/db/data/development-data/subdivisions/valid-subdivision-types.ts
@@ -1,17 +1,17 @@
 export const subdivisionTypeData: { type: string }[] = [
   {
-    type: "bed"
+    type: "Bed"
   },
   {
-    type: "flowerbed"
+    type: "Flowerbed"
   },
   {
-    type: "herb garden"
+    type: "Herb garden"
   },
   {
-    type: "row"
+    type: "Row"
   },
   {
-    type: "vegetable patch"
+    type: "Vegetable patch"
   }
 ]

--- a/src/db/data/test-data/crops/crop-categories.ts
+++ b/src/db/data/test-data/crops/crop-categories.ts
@@ -1,0 +1,26 @@
+export const cropCategoryData: {category: string}[] = [
+  {
+    category: "Fruits"
+  },
+  {
+    category: "Fungi"
+  },
+  {
+    category: "Grains"
+  },
+  {
+    category: "Herbs and spices"
+  },
+  {
+    category: "Legumes"
+  },
+  {
+    category: "Nuts and seeds"
+  },
+  {
+    category: "Ornamental plants"
+  },
+  {
+    category: "Vegetables"
+  }
+]

--- a/src/db/data/test-data/crops/crops.ts
+++ b/src/db/data/test-data/crops/crops.ts
@@ -5,7 +5,7 @@ export const cropData: Crop[] = [
   {
     plot_id: 1,
     subdivision_id: 1,
-    name: "carrot",
+    name: "Carrot",
     variety: null,
     quantity: 20,
     date_planted: new Date("2024-06-20"),
@@ -14,8 +14,8 @@ export const cropData: Crop[] = [
   {
     plot_id: 1,
     subdivision_id: null,
-    name: "apple",
-    variety: "lord derby",
+    name: "Apple",
+    variety: "Lord Derby",
     quantity: 1,
     date_planted: new Date("2023-09-21"),
     harvest_date: new Date("2024-09-21")
@@ -23,7 +23,7 @@ export const cropData: Crop[] = [
   {
     plot_id: 1,
     subdivision_id: null,
-    name: "cabbage",
+    name: "Cabbage",
     variety: null,
     quantity: null,
     date_planted:  null,
@@ -32,7 +32,7 @@ export const cropData: Crop[] = [
   {
     plot_id: 1,
     subdivision_id: 1,
-    name: "pecan",
+    name: "Pecan",
     variety: null,
     quantity: 1,
     date_planted: new Date("2024-07-19"),
@@ -41,7 +41,7 @@ export const cropData: Crop[] = [
   {
     plot_id: 2,
     subdivision_id: null,
-    name: "peach",
+    name: "Peach",
     variety: null,
     quantity: 2,
     date_planted: new Date("2020-06-30"),
@@ -50,7 +50,7 @@ export const cropData: Crop[] = [
   {
     plot_id: 2,
     subdivision_id: null,
-    name: "blackcurrant",
+    name: "Blackcurrant",
     variety: null,
     quantity: null,
     date_planted: new Date("2022-08-30"),

--- a/src/db/data/test-data/crops/crops.ts
+++ b/src/db/data/test-data/crops/crops.ts
@@ -7,6 +7,7 @@ export const cropData: Crop[] = [
     subdivision_id: 1,
     name: "Carrot",
     variety: null,
+    category: "Vegetables",
     quantity: 20,
     date_planted: new Date("2024-06-20"),
     harvest_date: new Date("2024-09-15")
@@ -16,6 +17,7 @@ export const cropData: Crop[] = [
     subdivision_id: null,
     name: "Apple",
     variety: "Lord Derby",
+    category: "Fruits",
     quantity: 1,
     date_planted: new Date("2023-09-21"),
     harvest_date: new Date("2024-09-21")
@@ -25,6 +27,7 @@ export const cropData: Crop[] = [
     subdivision_id: null,
     name: "Cabbage",
     variety: null,
+    category: "Vegetables",
     quantity: null,
     date_planted:  null,
     harvest_date: null
@@ -34,6 +37,7 @@ export const cropData: Crop[] = [
     subdivision_id: 1,
     name: "Pecan",
     variety: null,
+    category: "Nuts and seeds",
     quantity: 1,
     date_planted: new Date("2024-07-19"),
     harvest_date: new Date("2026-07-19")
@@ -43,6 +47,7 @@ export const cropData: Crop[] = [
     subdivision_id: null,
     name: "Peach",
     variety: null,
+    category: "Fruits",
     quantity: 2,
     date_planted: new Date("2020-06-30"),
     harvest_date: new Date("2024-07-25")
@@ -52,6 +57,7 @@ export const cropData: Crop[] = [
     subdivision_id: null,
     name: "Blackcurrant",
     variety: null,
+    category: "Fruits",
     quantity: null,
     date_planted: new Date("2022-08-30"),
     harvest_date: new Date("2024-07-14")

--- a/src/db/data/test-data/plots/plots.ts
+++ b/src/db/data/test-data/plots/plots.ts
@@ -5,7 +5,7 @@ export const plotData: Plot[] = [
   {
     owner_id: 1,
     name: "John's Garden",
-    type: "garden",
+    type: "Garden",
     description: "A vegetable garden",
     location: "Farmville",
     area: 100,
@@ -14,7 +14,7 @@ export const plotData: Plot[] = [
   {
     owner_id: 2,
     name: "Olivia's Field",
-    type: "field",
+    type: "Field",
     description: "An orchard",
     location: "Lemongrove",
     area: 500,
@@ -23,7 +23,7 @@ export const plotData: Plot[] = [
   {
     owner_id: 1,
     name: "John's Allotment",
-    type: "allotment",
+    type: "Allotment",
     description: "An allotment",
     location: "Farmville",
     area: 50,
@@ -32,7 +32,7 @@ export const plotData: Plot[] = [
   {
     owner_id: 1,
     name: "John's New Allotment",
-    type: "allotment",
+    type: "Allotment",
     description: "A second allotment",
     location: "Farmville",
     area: 40,

--- a/src/db/data/test-data/plots/valid-plot-types.ts
+++ b/src/db/data/test-data/plots/valid-plot-types.ts
@@ -1,17 +1,17 @@
 export const plotTypeData: {type: string}[] = [
   {
-    type: "allotment"
+    type: "Allotment"
   },
   {
-    type: "field"
+    type: "Field"
   },
   {
-    type: "garden"
+    type: "Garden"
   },
   {
-    type: "homestead"
+    type: "Homestead"
   },
   {
-    type: "orchard"
+    type: "Orchard"
   }
 ]

--- a/src/db/data/test-data/subdivisions/subdivisions.ts
+++ b/src/db/data/test-data/subdivisions/subdivisions.ts
@@ -5,28 +5,28 @@ export const subdivisionData: Subdivision[] = [
   {
     plot_id: 1,
     name: "Root Vegetable Bed",
-    type: "bed",
+    type: "Bed",
     description: "Carrots, beetroots, and parsnips",
     area: 10
   },
   {
     plot_id: 1,
     name: "Onion Bed",
-    type: "bed",
+    type: "Bed",
     description: "Red onions, garlic, and shallots",
     area: 10
   },
   {
     plot_id: 1,
     name: "Woody Herbs",
-    type: "herb garden",
+    type: "Herb garden",
     description: "Rosemary and thyme",
     area: null
   },
   {
     plot_id: 2,
     name: "Cooking Apples",
-    type: "row",
+    type: "Row",
     description: "Bramley and Lord Derby apple trees",
     area: 20
   }

--- a/src/db/data/test-data/subdivisions/valid-subdivision-types.ts
+++ b/src/db/data/test-data/subdivisions/valid-subdivision-types.ts
@@ -1,17 +1,17 @@
 export const subdivisionTypeData: { type: string }[] = [
   {
-    type: "bed"
+    type: "Bed"
   },
   {
-    type: "flowerbed"
+    type: "Flowerbed"
   },
   {
-    type: "herb garden"
+    type: "Herb garden"
   },
   {
-    type: "row"
+    type: "Row"
   },
   {
-    type: "vegetable patch"
+    type: "Vegetable patch"
   }
 ]

--- a/src/db/data/test-data/test-index.ts
+++ b/src/db/data/test-data/test-index.ts
@@ -8,6 +8,7 @@ import { subdivisionTypeData } from "./subdivisions/valid-subdivision-types"
 import { cropData } from "./crops/crops"
 import { cropNoteData } from "./crops/crop-notes"
 import { cropImageData } from "./crops/crop-images"
+import { cropCategoryData } from "./crops/crop-categories"
 import { issueData } from "./issues/issues"
 import { issueNoteData } from "./issues/issue-notes"
 import { issueImageData } from "./issues/issue-images"
@@ -26,6 +27,7 @@ export default {
   cropData,
   cropNoteData,
   cropImageData,
+  cropCategoryData,
   issueData,
   issueNoteData,
   issueImageData,

--- a/src/db/seeding/seed.ts
+++ b/src/db/seeding/seed.ts
@@ -128,7 +128,7 @@ export const seed = async (
 
   await db.query(`
     CREATE TABLE plot_types (
-      plot_type_id SERIAL PRIMARY KEY,
+      type_id SERIAL PRIMARY KEY,
       type VARCHAR NOT NULL
     );
     `)
@@ -154,7 +154,7 @@ export const seed = async (
 
   await db.query(`
     CREATE TABLE subdivision_types (
-      subdivision_type_id SERIAL PRIMARY KEY,
+      type_id SERIAL PRIMARY KEY,
       type VARCHAR NOT NULL
     );
     `)

--- a/src/db/seeding/seed.ts
+++ b/src/db/seeding/seed.ts
@@ -16,6 +16,7 @@ export const seed = async (
     cropData,
     cropNoteData,
     cropImageData,
+    cropCategoryData,
     issueData,
     issueNoteData,
     issueImageData,
@@ -42,6 +43,10 @@ export const seed = async (
 
   await db.query(`
     DROP TABLE IF EXISTS issues;
+    `)
+
+  await db.query(`
+    DROP TABLE IF EXISTS crop_categories;
     `)
 
   await db.query(`
@@ -190,6 +195,13 @@ export const seed = async (
     `)
 
   await db.query(`
+    CREATE TABLE crop_categories (
+      category_id SERIAL PRIMARY KEY,
+      category VARCHAR NOT NULL
+    );
+    `)
+
+  await db.query(`
     CREATE TABLE issues (
       issue_id SERIAL PRIMARY KEY,
       plot_id INT NOT NULL REFERENCES plots(plot_id) ON DELETE CASCADE,
@@ -331,6 +343,14 @@ export const seed = async (
     VALUES %L;
     `,
     cropImageData.map(entry => Object.values(entry))
+  ))
+
+  await db.query(format(`
+    INSERT INTO crop_categories 
+      (category)
+    VALUES %L;
+    `,
+    cropCategoryData.map(entry => Object.values(entry))
   ))
 
   await db.query(format(`

--- a/src/db/seeding/seed.ts
+++ b/src/db/seeding/seed.ts
@@ -171,6 +171,7 @@ export const seed = async (
       subdivision_id INT REFERENCES subdivisions(subdivision_id) ON DELETE CASCADE,
       name VARCHAR NOT NULL,
       variety VARCHAR,
+      category VARCHAR NOT NULL,
       quantity INT,
       date_planted DATE,
       harvest_date DATE
@@ -323,7 +324,7 @@ export const seed = async (
 
   await db.query(format(`
     INSERT INTO crops 
-      (plot_id, subdivision_id, name, variety, quantity, date_planted, harvest_date)
+      (plot_id, subdivision_id, name, variety, category, quantity, date_planted, harvest_date)
     VALUES %L;
     `,
     cropData.map(entry => Object.values(entry))

--- a/src/models/crops-models.ts
+++ b/src/models/crops-models.ts
@@ -113,12 +113,12 @@ export const insertCropByPlotId = async (
 
   const result = await db.query(format(`
     INSERT INTO crops
-      (plot_id, name, variety, quantity, date_planted, harvest_date)
+      (plot_id, name, variety, category, quantity, date_planted, harvest_date)
     VALUES
       %L
     RETURNING *;
     `,
-    [[plot_id, crop.name, crop.variety, crop.quantity, crop.date_planted, crop.harvest_date]]
+    [[plot_id, crop.name, crop.variety, crop.category, crop.quantity, crop.date_planted, crop.harvest_date]]
   ))
 
   return result.rows[0]
@@ -232,12 +232,12 @@ export const insertCropBySubdivisionId = async (
 
   const result = await db.query(format(`
     INSERT INTO crops
-      (plot_id, subdivision_id, name, variety, quantity, date_planted, harvest_date)
+      (plot_id, subdivision_id, name, variety, category, quantity, date_planted, harvest_date)
     VALUES
       %L
     RETURNING *;
     `,
-    [[plotId, subdivision_id, crop.name, crop.variety, crop.quantity, crop.date_planted, crop.harvest_date]]
+    [[plotId, subdivision_id, crop.name, crop.variety, crop.category, crop.quantity, crop.date_planted, crop.harvest_date]]
   ))
 
   return result.rows[0]

--- a/src/models/crops-models.ts
+++ b/src/models/crops-models.ts
@@ -1,7 +1,7 @@
 import QueryString from "qs"
 import { db } from "../db"
 import { Crop, CropRequest, ExtendedCrop } from "../types/crop-types"
-import { getPlotOwnerId, getSubdivisionPlotId } from "../utils/db-queries"
+import { getPlotOwnerId, getSubdivisionPlotId, validateCropCategory } from "../utils/db-queries"
 import { verifyPagination, verifyParamIsPositiveInt, verifyPermission, verifyQueryValue } from "../utils/verification"
 import format from "pg-format"
 
@@ -110,6 +110,16 @@ export const insertCropByPlotId = async (
   const owner_id = await getPlotOwnerId(plot_id)
 
   await verifyPermission(authUserId, owner_id, "Permission to add crop denied")
+
+  const isValidCropCategory = await validateCropCategory(crop.category, false)
+
+  if (!isValidCropCategory) {
+    return Promise.reject({
+      status: 400,
+      message: "Bad Request",
+      details: "Invalid crop category"
+    })
+  }
 
   const result = await db.query(format(`
     INSERT INTO crops
@@ -229,6 +239,16 @@ export const insertCropBySubdivisionId = async (
   const owner_id = await getPlotOwnerId(plotId)
 
   await verifyPermission(authUserId, owner_id, "Permission to add crop denied")
+
+  const isValidCropCategory = await validateCropCategory(crop.category, false)
+
+  if (!isValidCropCategory) {
+    return Promise.reject({
+      status: 400,
+      message: "Bad Request",
+      details: "Invalid crop category"
+    })
+  }
 
   const result = await db.query(format(`
     INSERT INTO crops

--- a/src/models/login-models.ts
+++ b/src/models/login-models.ts
@@ -4,7 +4,7 @@ import { Credentials, LoggedInUser } from "../types/user-types"
 
 
 export const logInUser = async (
-  { username, password }: Credentials
+  { login, password }: Credentials
 ): Promise<LoggedInUser> => {
 
   const result = await db.query(`
@@ -12,24 +12,26 @@ export const logInUser = async (
       user_id, 
       username 
     FROM users 
-    WHERE username = $1;
+    WHERE username = $1
+    OR email = $1;
     `,
-    [username])
+    [login])
 
   if (!result.rowCount) {
     return Promise.reject({
       status: 404,
       message: "Not Found",
-      details: "Username could not be found"
+      details: "Username or email could not be found"
     })
   }
 
   const dbPassword = await db.query(`
     SELECT password
     FROM users
-    WHERE username = $1;
+    WHERE username = $1
+    OR email = $1;
     `,
-    [username])
+    [login])
 
   const isCorrectPassword = await compareHash(password, dbPassword.rows[0].password)
 

--- a/src/models/plots-models.ts
+++ b/src/models/plots-models.ts
@@ -34,7 +34,7 @@ export const selectPlotsByOwner = async (
 
   await verifyQueryValue(["asc", "desc"], order as string)
 
-  const isValidPlotType = await validatePlotType(type as string)
+  const isValidPlotType = await validatePlotType(type as string, true)
 
   if (type && !isValidPlotType) {
     return Promise.reject({
@@ -88,10 +88,10 @@ export const selectPlotsByOwner = async (
 
   if (type) {
     query += format(`
-      AND plots.type = %L
+      AND plots.type ILIKE %L
       `, type)
     countQuery += format(`
-      AND plots.type = %L
+      AND plots.type ILIKE %L
       `, type)
   }
 
@@ -133,7 +133,7 @@ export const insertPlotByOwner = async (
 
   await checkPlotNameConflict(owner_id, plot.name)
 
-  const isValidPlotType = await validatePlotType(plot.type)
+  const isValidPlotType = await validatePlotType(plot.type, false)
 
   if (!isValidPlotType) {
     return Promise.reject({
@@ -248,7 +248,7 @@ export const updatePlotByPlotId = async (
     await checkPlotNameConflict(owner_id, plot.name)
   }
 
-  const isValidPlotType = await validatePlotType(plot.type)
+  const isValidPlotType = await validatePlotType(plot.type, false)
 
   if (!isValidPlotType) {
     return Promise.reject({

--- a/src/models/subdivisions-models.ts
+++ b/src/models/subdivisions-models.ts
@@ -33,7 +33,7 @@ export const selectSubdivisionsByPlotId = async (
 
   await verifyQueryValue(["asc", "desc"], order as string)
 
-  const isValidSubdivisionType = await validateSubdivisionType(type as string)
+  const isValidSubdivisionType = await validateSubdivisionType(type as string, true)
 
   if (type && !isValidSubdivisionType) {
     return Promise.reject({
@@ -83,10 +83,10 @@ export const selectSubdivisionsByPlotId = async (
 
   if (type) {
     query += format(`
-      AND subdivisions.type = %L
+      AND subdivisions.type ILIKE %L
       `, type)
     countQuery += format(`
-      AND subdivisions.type = %L
+      AND subdivisions.type ILIKE %L
       `, type)
   }
 
@@ -128,7 +128,7 @@ export const insertSubdivisionByPlotId = async (
 
   await checkSubdivisionNameConflict(plot_id, subdivision.name)
 
-  const isValidSubdivisionType = await validateSubdivisionType(subdivision.type as string)
+  const isValidSubdivisionType = await validateSubdivisionType(subdivision.type as string, false)
 
   if (!isValidSubdivisionType) {
     return Promise.reject({
@@ -223,7 +223,7 @@ export const updateSubdivisionBySubdivisionId = async (
     await checkSubdivisionNameConflict(plotId, subdivision.name)
   }
 
-  const isValidSubdivisionType = await validateSubdivisionType(subdivision.type)
+  const isValidSubdivisionType = await validateSubdivisionType(subdivision.type, false)
 
   if (!isValidSubdivisionType) {
     return Promise.reject({

--- a/src/routes/login-router.ts
+++ b/src/routes/login-router.ts
@@ -10,7 +10,7 @@ export const loginRouter = Router()
  * /api/login:
  *  post:
  *    summary: Log in a user
- *    description: Responds with a JSON Web Token. The server responds with an error if the username does not exist or the password is incorrect.
+ *    description: Responds with a JSON Web Token. The server responds with an error if the username or email does not exist or the password is incorrect.
  *    tags: [Login]
  *    requestBody:
  *      required: true
@@ -19,7 +19,7 @@ export const loginRouter = Router()
  *          schema:
  *            type: object
  *            properties:
- *              username:
+ *              login:
  *                type: string
  *                example: admin
  *              password:
@@ -53,6 +53,6 @@ export const loginRouter = Router()
  *                  example: Not Found
  *                details:
  *                  type: string
- *                  example: Username could not be found
+ *                  example: Username or email could not be found
  */
 loginRouter.post("/login", postLogin)

--- a/src/routes/swagger-schemas.ts
+++ b/src/routes/swagger-schemas.ts
@@ -46,6 +46,9 @@ export const schemaRouter = Router()
  *          type: string
  *          nullable: true
  *          example: Chantenay
+ *        category:
+ *          type: string
+ *          example: Vegetables
  *        quantity:
  *          type: integer
  *          nullable: true
@@ -68,6 +71,9 @@ export const schemaRouter = Router()
  *          type: string
  *          nullable: true
  *          example: Chantenay
+ *        category:
+ *          type: string
+ *          example: Vegetables
  *        quantity:
  *          type: integer
  *          nullable: true

--- a/src/types/crop-types.ts
+++ b/src/types/crop-types.ts
@@ -4,6 +4,7 @@ export type Crop = {
   subdivision_id: number | null
   name: string
   variety: string | null
+  category: string
   quantity: number | null
   date_planted: Date | null
   harvest_date: Date | null
@@ -20,6 +21,7 @@ export type ExtendedCrop = {
 export type CropRequest = {
   name: string
   variety?: string | null
+  category: string
   quantity?: number | null
   date_planted?: Date | null
   harvest_date?: Date | null

--- a/src/types/seed-types.ts
+++ b/src/types/seed-types.ts
@@ -9,19 +9,20 @@ import { User } from "./user-types"
 
 
 export type SeedData = {
-  userData: User[],
-  plotData: Plot[],
-  plotImageData: PlotImage[],
-  plotTypeData: { type: string }[],
-  subdivisionData: Subdivision[],
-  subdivisionImageData: SubdivisionImage[],
-  subdivisionTypeData: { type: string }[],
-  cropData: Crop[],
-  cropNoteData: CropNote[],
-  cropImageData: CropImage[],
-  issueData: Issue[],
-  issueNoteData: IssueNote[],
-  issueImageData: IssueImage[],
-  jobData: Job[],
+  userData: User[]
+  plotData: Plot[]
+  plotImageData: PlotImage[]
+  plotTypeData: { type: string }[]
+  subdivisionData: Subdivision[]
+  subdivisionImageData: SubdivisionImage[]
+  subdivisionTypeData: { type: string }[]
+  cropData: Crop[]
+  cropNoteData: CropNote[]
+  cropImageData: CropImage[]
+  cropCategoryData: { category: string }[]
+  issueData: Issue[]
+  issueNoteData: IssueNote[]
+  issueImageData: IssueImage[]
+  jobData: Job[]
   jobImageData: JobImage[]
 }

--- a/src/types/user-types.ts
+++ b/src/types/user-types.ts
@@ -8,7 +8,9 @@ export type Password = {
 }
 
 
-export type Credentials = Username & Password
+export type Credentials = {
+  login: string
+} & Password
 
 
 export type LoggedInUser = {

--- a/src/utils/db-queries.ts
+++ b/src/utils/db-queries.ts
@@ -150,6 +150,22 @@ export const searchForUsername = async (
 }
 
 
+export const validateCropCategory = async (
+  category: string,
+  ignoreCase: boolean
+): Promise<boolean> => {
+
+  const result = await db.query(`
+    SELECT category 
+    FROM crop_categories
+    WHERE category ${ignoreCase ? "ILIKE" : "="} $1;
+    `,
+    [category])
+
+  return Boolean(result.rows.length)
+}
+
+
 export const validatePlotType = async (
   type: string,
   ignoreCase: boolean

--- a/src/utils/db-queries.ts
+++ b/src/utils/db-queries.ts
@@ -151,26 +151,32 @@ export const searchForUsername = async (
 
 
 export const validatePlotType = async (
-  type: string
+  type: string,
+  ignoreCase: boolean
 ): Promise<boolean> => {
 
   const result = await db.query(`
     SELECT type 
-    FROM plot_types;
-    `)
+    FROM plot_types
+    WHERE type ${ignoreCase ? "ILIKE" : "="} $1;
+    `,
+    [type])
 
-  return result.rows.map(row => row.type).includes(type)
+  return Boolean(result.rows.length)
 }
 
 
 export const validateSubdivisionType = async (
-  type: string
+  type: string,
+  ignoreCase: boolean
 ): Promise<boolean> => {
 
   const result = await db.query(`
     SELECT type 
-    FROM subdivision_types;
-    `)
+    FROM subdivision_types
+    WHERE type ${ignoreCase ? "ILIKE" : "="} $1;
+    `,
+    [type])
 
-  return result.rows.map(row => row.type).includes(type)
+  return Boolean(result.rows.length)
 }


### PR DESCRIPTION
### Utils

- Updated `validatePlotType` and `validateSubdivisionType` to include an `ignoreCase` parameter

### Tests

- Replaced 'example' with 'foobar' in test cases

### Plots

- Capitalised types in `valid-plot-types.ts` and `plots.ts` for test and dev data
- Updated models to ignore case when searching for valid plot types on GET requests, but to check case on POST and PATCH requests
- Updated test suite

### Subdivisions

- Capitalised types in `valid-subdivision-types.ts` and `subdivisions.ts` for test and dev data
- Updated models to ignore case when searching for valid plot types on GET requests, but to check case on POST and PATCH requests
- Updated test suite

### Login

- Updated `logInUser` model to accept username or email for login
- Updated `Credentials` in `user-types.ts`
- Updated login test cases
- Updated request body for login in other test suites

### Crop Categories

- Added `crop-categories.ts` to test and dev data with a list of valid crop categories
- Updated `test-index.ts` and `development-index.ts` to import and export `cropCategoryData`
- Updated `SeedData` type to include `cropCategoryData`
- Updated seed to drop, create, and populate `crop_categories` table
- Updated `Crop` and `CropRequest` types to include `category` property
- Updated `crops.ts` in test and dev data with values for `category`
- Updated `crops` table in seed to include `category` 
- Added `validateCropCategory` to `db-queries.ts`
- Updated `insertCropByPlotId` and `insertCropBySubdivisionId` to insert values for the `category` field and check that the crop category on the request body is valid
- Updated test cases for `crops.test.ts` to handle new `category` property on crop objects and confirm crop category validation is working
- Updated `Crop` and `CropRequest` schemas in `swagger-schemas.ts`