### PR TITLE
Patch crop location

### DIFF
--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -1579,3 +1579,156 @@ describe("PATCH /api/crops/:crop_id", () => {
     })
   })
 })
+
+
+describe("PATCH /api/crops/:crop_id/plot", () => {
+
+  test("PATCH:200 Responds with an updated crop object, assigning a null value to subdivision_id automatically", async () => {
+
+    const newPlot = {
+      plot_id: 3
+    }
+
+    const { body } = await request(app)
+      .patch("/api/crops/1/plot")
+      .send(newPlot)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+
+    expect(body.crop).toMatchObject<Crop>({
+      crop_id: 1,
+      plot_id: 3,
+      subdivision_id: null,
+      name: "Carrot",
+      variety: null,
+      category: "Vegetables",
+      quantity: 20,
+      date_planted: expect.toBeOneOf([expect.stringMatching(regex), null]),
+      harvest_date: expect.toBeOneOf([expect.stringMatching(regex), null])
+    })
+  })
+
+  test("PATCH:400 Responds with an error when a required property is missing from the request body", async () => {
+
+    const newPlot = {}
+
+    const { body } = await request(app)
+      .patch("/api/crops/1/plot")
+      .send(newPlot)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Bad Request",
+      details: "Not null violation"
+    })
+  })
+
+  test("PATCH:400 Responds with an error when passed a property with an invalid data type", async () => {
+
+    const newPlot = {
+      plot_id: "three"
+    }
+
+    const { body } = await request(app)
+      .patch("/api/crops/1/plot")
+      .send(newPlot)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Bad Request",
+      details: "Invalid text representation"
+    })
+  })
+
+  test("PATCH:400 Responds with an error whe the crop_id parameter is not a positive integer", async () => {
+
+    const newPlot = {
+      plot_id: 3
+    }
+
+    const { body } = await request(app)
+      .patch("/api/crops/foobar/plot")
+      .send(newPlot)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Bad Request",
+      details: "Invalid parameter"
+    })
+  })
+
+  test("PATCH:403 Responds with an error when the crop does not belong to the authenticated user", async () => {
+
+    const newPlot = {
+      plot_id: 3
+    }
+
+    const { body } = await request(app)
+      .patch("/api/crops/5/plot")
+      .send(newPlot)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(403)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Forbidden",
+      details: "Permission to move crop denied"
+    })
+  })
+
+  test("PATCH:403 Responds with an error when the target plot does not belong to the authenticated user", async () => {
+
+    const newPlot = {
+      plot_id: 2
+    }
+
+    const { body } = await request(app)
+      .patch("/api/crops/1/plot")
+      .send(newPlot)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(403)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Forbidden",
+      details: "Permission to move crop denied"
+    })
+  })
+
+  test("PATCH:404 Responds with an error when the crop does not exist", async () => {
+
+    const newPlot = {
+      plot_id: 3
+    }
+
+    const { body } = await request(app)
+      .patch("/api/crops/999/plot")
+      .send(newPlot)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(404)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Not Found",
+      details: "Crop not found"
+    })
+  })
+
+  test("PATCH:404 Responds with an error when the target plot does not exist", async () => {
+
+    const newPlot = {
+      plot_id: 999
+    }
+
+    const { body } = await request(app)
+      .patch("/api/crops/1/plot")
+      .send(newPlot)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(404)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Not Found",
+      details: "Plot not found"
+    })
+  })
+})

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -855,7 +855,7 @@ describe("PATCH /api/users/:user_id/role", () => {
 
     expect(body).toMatchObject<StatusResponse>({
       message: "Forbidden",
-      details: "Permission to edit user data denied"
+      details: "Permission to edit user role denied"
     })
   })
 

--- a/src/controllers/crops-controllers.ts
+++ b/src/controllers/crops-controllers.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Response } from "express"
-import { insertCropByPlotId, insertCropBySubdivisionId, selectCropByCropId, selectCropsByPlotId, selectCropsBySubdivisionId, updateCropByCropId } from "../models/crops-models"
+import { insertCropByPlotId, insertCropBySubdivisionId, selectCropByCropId, selectCropsByPlotId, selectCropsBySubdivisionId, updateAssociatedPlotByCropId, updateCropByCropId } from "../models/crops-models"
 import { ExtendedRequest } from "../types/auth-types"
 
 
@@ -86,6 +86,21 @@ export const patchCropByCropId = async (req: ExtendedRequest, res: Response, nex
 
   try {
     const crop = await updateCropByCropId(authUserId, +crop_id, req.body)
+    res.status(200).send({ crop })
+  } catch (err) {
+    next(err)
+  }
+}
+
+
+export const patchAssociatedPlotByCropId = async (req: ExtendedRequest, res: Response, next: NextFunction) => {
+
+  const authUserId = req.user!.user_id
+
+  const { crop_id } = req.params
+
+  try {
+    const crop = await updateAssociatedPlotByCropId(authUserId, +crop_id, req.body)
     res.status(200).send({ crop })
   } catch (err) {
     next(err)

--- a/src/models/crops-models.ts
+++ b/src/models/crops-models.ts
@@ -409,3 +409,36 @@ export const updateCropByCropId = async (
 
   return result.rows[0]
 }
+
+
+export const updateAssociatedPlotByCropId = async (
+  authUserId: number,
+  crop_id: number,
+  { plot_id }: { plot_id: number }
+): Promise<Crop> => {
+
+  await verifyParamIsPositiveInt(crop_id)
+
+  let owner_id = await getCropOwnerId(crop_id)
+
+  await verifyPermission(authUserId, owner_id, "Permission to move crop denied")
+
+  if (plot_id) {
+    owner_id = await getPlotOwnerId(plot_id)
+
+    await verifyPermission(authUserId, owner_id, "Permission to move crop denied")
+  }
+
+  const result = await db.query(`
+    UPDATE crops
+    SET 
+      plot_id = $1,
+      subdivision_id = NULL
+    WHERE crop_id = $2
+    RETURNING *;
+    `,
+    [plot_id, crop_id]
+  )
+
+  return result.rows[0]
+}

--- a/src/models/users-models.ts
+++ b/src/models/users-models.ts
@@ -256,7 +256,7 @@ export const updateRoleByUserId = async (
 
   const userRole = await getUserRole(authUserId)
 
-  await verifyPermission(userRole, "admin", "Permission to edit user data denied")
+  await verifyPermission(userRole, "admin", "Permission to edit user role denied")
 
   const result = await db.query(`
     UPDATE users

--- a/src/routes/crops-router.ts
+++ b/src/routes/crops-router.ts
@@ -1,6 +1,6 @@
 import { Router } from "express"
 import { verifyToken } from "../middleware/authentication"
-import { getCropByCropId, getCropsByPlotId, getCropsBySubdivisionId, patchCropByCropId, postCropByPlotId, postCropBySubdivisionId } from "../controllers/crops-controllers"
+import { getCropByCropId, getCropsByPlotId, getCropsBySubdivisionId, patchAssociatedPlotByCropId, patchCropByCropId, postCropByPlotId, postCropBySubdivisionId } from "../controllers/crops-controllers"
 
 
 export const cropsRouter = Router()
@@ -417,3 +417,62 @@ cropsRouter.route("/crops/:crop_id")
  *              $ref: "#/components/schemas/NotFound"
  */
   .patch(verifyToken, patchCropByCropId)
+
+
+cropsRouter.route("/crops/:crop_id/plot")
+
+/**
+ * @swagger
+ * /api/crops/{crop_id}/plot:
+ *  patch:
+ *    security:
+ *      - bearerAuth: []
+ *    summary: Update a crop's assigned plot
+ *    description: Responds with an updated crop object. If the request body or crop_id parameter is invalid, the server responds with an error. Permission is denied when the crop or target plot does not belong to the user.
+ *    tags: [Crops]
+ *    parameters:
+ *      - in: path
+ *        name: crop_id
+ *        required: true
+ *        schema:
+ *          type: integer
+ *    requestBody:
+ *      required: true
+ *      content:
+ *        application/json:
+ *          schema:
+ *            type: object
+ *            properties:
+ *              plot_id:
+ *                type: integer
+ *                example: 2
+ *    responses:
+ *      200:
+ *        description: OK
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                crop:
+ *                  $ref: "#/components/schemas/Crop"
+ *      400:
+ *        description: Bad Request
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/BadRequest"
+ *      403:
+ *        description: Forbidden
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/Forbidden"
+ *      404:
+ *        description: Not Found
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/NotFound"
+ */
+  .patch(verifyToken, patchAssociatedPlotByCropId)

--- a/src/swagger/options.ts
+++ b/src/swagger/options.ts
@@ -3,7 +3,7 @@ export const options = {
     openapi: "3.1.0",
     info: {
       title: "Agriculture API",
-      description: "A full-stack application for gardeners, allotment owners, and other subsistence farmers to keep track of crops and jobs on their plots.",
+      description: "API for gardeners, allotment owners, and other subsistence farmers to keep track of crops, issues, and jobs on their plots.",
       version: "1.0.0"
     },
     components: {


### PR DESCRIPTION
### Summary

- Added new /api/crops/:crop_id/plot route to patch a crop's plot ID
- Added `patchAssociatedPlotByCropId` controller
- Added `updateAssociatedPlotByCropId` model
- Added tests for PATCH /api/crops/:crop_id/plot