### PR TITLE
Get issues by plot queries

### DIFF
--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -43,7 +43,7 @@ describe("GET /api/crops/plots/:plot_id", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
+    const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.crop_id! < b.crop_id!) return 1
       if (a.crop_id! > b.crop_id!) return -1
       return 0
@@ -235,7 +235,7 @@ describe("GET /api/crops/plots/:plot_id?sort=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
+    const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.name > b.name) return 1
       if (a.name < b.name) return -1
       return 0
@@ -257,7 +257,7 @@ describe("GET /api/crops/plots/:plot_id?sort=", () => {
       expect(crop.date_planted).not.toBeNull()
     }
 
-    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
+    const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.date_planted! < b.date_planted!) return 1
       if (a.date_planted! > b.date_planted!) return -1
       return 0
@@ -279,7 +279,7 @@ describe("GET /api/crops/plots/:plot_id?sort=", () => {
       expect(crop.harvest_date).not.toBeNull()
     }
 
-    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
+    const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.harvest_date! < b.harvest_date!) return 1
       if (a.harvest_date! > b.harvest_date!) return -1
       return 0
@@ -318,7 +318,7 @@ describe("GET /api/crops/plots/:plot_id?name=&sort=", () => {
       expect(crop.name).toMatch(/ca/i)
     }
 
-    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
+    const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.name > b.name) return 1
       if (a.name < b.name) return -1
       return 0
@@ -340,7 +340,7 @@ describe("GET /api/crops/plots/:plot_id?name=&sort=", () => {
       expect(crop.name).toMatch(/ca/i)
     }
 
-    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
+    const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.harvest_date! < b.harvest_date!) return 1
       if (a.harvest_date! > b.harvest_date!) return -1
       return 0
@@ -696,7 +696,7 @@ describe("GET /api/crops/subdivisions/:subdivision_id", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
+    const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.crop_id! < b.crop_id!) return 1
       if (a.crop_id! > b.crop_id!) return -1
       return 0
@@ -887,7 +887,7 @@ describe("GET /api/crops/subdivisions/:subdivision_id?sort=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
+    const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.name > b.name) return 1
       if (a.name < b.name) return -1
       return 0
@@ -909,7 +909,7 @@ describe("GET /api/crops/subdivisions/:subdivision_id?sort=", () => {
       expect(crop.date_planted).not.toBeNull()
     }
 
-    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
+    const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.date_planted! < b.date_planted!) return 1
       if (a.date_planted! > b.date_planted!) return -1
       return 0
@@ -931,7 +931,7 @@ describe("GET /api/crops/subdivisions/:subdivision_id?sort=", () => {
       expect(crop.date_planted).not.toBeNull()
     }
 
-    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
+    const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.harvest_date! < b.harvest_date!) return 1
       if (a.harvest_date! > b.harvest_date!) return -1
       return 0
@@ -970,7 +970,7 @@ describe("GET /api/crops/subdivisions/:subdivision_id?name=&sort=", () => {
       expect(crop.name).toMatch(/car/i)
     }
 
-    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
+    const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.name > b.name) return 1
       if (a.name < b.name) return -1
       return 0
@@ -992,7 +992,7 @@ describe("GET /api/crops/subdivisions/:subdivision_id?name=&sort=", () => {
       expect(crop.name).toMatch(/car/i)
     }
 
-    const sortedCrops = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
+    const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
       if (a.harvest_date! < b.harvest_date!) return 1
       if (a.harvest_date! > b.harvest_date!) return -1
       return 0

--- a/src/__tests__/issues.test.ts
+++ b/src/__tests__/issues.test.ts
@@ -63,6 +63,8 @@ describe("GET /api/issues/plots/:plot_id", () => {
         image_count: expect.any(Number)
       })
     }
+
+    expect(body.count).toBe(3)
   })
 
   test("GET:200 Responds with an empty array when no crops are associated with the plot", async () => {
@@ -75,6 +77,8 @@ describe("GET /api/issues/plots/:plot_id", () => {
     expect(Array.isArray(body.issues)).toBe(true)
 
     expect(body.issues).toHaveLength(0)
+
+    expect(body.count).toBe(0)
   })
 
   test("GET:400 Responds with an error when the plot_id parameter is not a positive integer", async () => {
@@ -148,6 +152,8 @@ describe("GET /api/issues/plots/:plot_id?is_critical=", () => {
     for (const issue of body.issues) {
       expect(issue.is_critical).toBe(true)
     }
+
+    expect(body.count).toBe(2)
   })
 
   test("GET:200 Returns an empty array when the value of is_critical matches no results", async () => {
@@ -169,6 +175,8 @@ describe("GET /api/issues/plots/:plot_id?is_critical=", () => {
     expect(Array.isArray(body.issues)).toBe(true)
 
     expect(body.issues).toHaveLength(0)
+
+    expect(body.count).toBe(0)
   })
 
   test("GET:400 Responds with an error when passed an invalid value for is_critical", async () => {
@@ -198,6 +206,8 @@ describe("GET /api/issues/plots/:plot_id?is_resolved=", () => {
     for (const issue of body.issues) {
       expect(issue.is_resolved).toBe(true)
     }
+
+    expect(body.count).toBe(1)
   })
 
   test("GET:200 Returns an empty array when the value of is_resolved matches no results", async () => {
@@ -219,6 +229,8 @@ describe("GET /api/issues/plots/:plot_id?is_resolved=", () => {
     expect(Array.isArray(body.issues)).toBe(true)
 
     expect(body.issues).toHaveLength(0)
+
+    expect(body.count).toBe(0)
   })
 
   test("GET:400 Responds with an error when passed an invalid value for is_resolved", async () => {
@@ -252,6 +264,8 @@ describe("GET /api/issues/plots/:plot_id?sort=", () => {
     })
 
     expect(body.issues).toEqual(sortedIssues)
+
+    expect(body.count).toBe(3)
   })
 
   test("GET:400 Responds with an error when passed an invalid sort value", async () => {
@@ -289,6 +303,8 @@ describe("GET /api/issues/plots/:plot_id?is_critical=&sort=", () => {
     })
 
     expect(body.issues).toEqual(sortedIssues)
+
+    expect(body.count).toBe(2)
   })
 })
 
@@ -320,6 +336,8 @@ describe("GET /api/issues/plots/:plot_id?limit=", () => {
       .expect(200)
 
     expect(body.issues).toHaveLength(2)
+
+    expect(body.count).toBe(3)
   })
 
   test("GET:200 Responds with an array of all issues associated with the plot when the limit exceeds the total number of results", async () => {
@@ -330,6 +348,8 @@ describe("GET /api/issues/plots/:plot_id?limit=", () => {
       .expect(200)
 
     expect(body.issues).toHaveLength(3)
+
+    expect(body.count).toBe(3)
   })
 
   test("GET:400 Responds with an error when the value of limit is not a positive integer", async () => {
@@ -359,6 +379,8 @@ describe("GET /api/issues/plots/:plot_id?page=", () => {
     expect(body.issues.map((issue: ExtendedIssue) => {
       return issue.issue_id
     })).toEqual([1])
+
+    expect(body.count).toBe(3)
   })
 
   test("GET:200 The page defaults to page one", async () => {
@@ -371,6 +393,8 @@ describe("GET /api/issues/plots/:plot_id?page=", () => {
     expect(body.issues.map((issue: ExtendedIssue) => {
       return issue.issue_id
     })).toEqual([3, 2])
+
+    expect(body.count).toBe(3)
   })
 
   test("GET:400 Responds with an error when the value of page is not a positive integer", async () => {

--- a/src/__tests__/issues.test.ts
+++ b/src/__tests__/issues.test.ts
@@ -41,7 +41,7 @@ describe("GET /api/issues/plots/:plot_id", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedIssues = [...body.issues].sort((a: ExtendedIssue, b: ExtendedIssue) => {
+    const sortedIssues: ExtendedIssue[] = [...body.issues].sort((a: ExtendedIssue, b: ExtendedIssue) => {
       if (a.issue_id! < b.issue_id!) return 1
       if (a.issue_id! > b.issue_id!) return -1
       return 0
@@ -225,6 +225,80 @@ describe("GET /api/issues/plots/:plot_id?is_resolved=", () => {
 
     const { body } = await request(app)
       .get("/api/issues/plots/1?is_resolved=foobar")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Bad Request",
+      details: "Invalid query value"
+    })
+  })
+})
+
+
+describe("GET /api/issues/plots/:plot_id?sort=", () => {
+
+  test("GET:200 Responds with an array of issues objects sorted by title in ascending order", async () => {
+
+    const { body } = await request(app)
+      .get("/api/issues/plots/1?sort=title")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+
+    const sortedIssues: ExtendedIssue[] = [...body.issues].sort((a: ExtendedIssue, b: ExtendedIssue) => {
+      if (a.title! > b.title!) return 1
+      if (a.title! < b.title!) return -1
+      return 0
+    })
+
+    expect(body.issues).toEqual(sortedIssues)
+  })
+
+  test("GET:400 Responds with an error when passed an invalid sort value", async () => {
+
+    const { body } = await request(app)
+      .get("/api/issues/plots/1?sort=foobar")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Bad Request",
+      details: "Invalid query value"
+    })
+  })
+})
+
+
+describe("GET /api/issues/plots/:plot_id?is_critical=&sort=", () => {
+
+  test("GET:200 Responds with an array of issues objects filtered by the value of is_critical and sorted by title in ascending order", async () => {
+
+    const { body } = await request(app)
+      .get("/api/issues/plots/1?is_critical=true&sort=title")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+
+    for (const issue of body.issues) {
+      expect(issue.is_critical).toBe(true)
+    }
+
+    const sortedIssues: ExtendedIssue[] = [...body.issues].sort((a: ExtendedIssue, b: ExtendedIssue) => {
+      if (a.title! > b.title!) return 1
+      if (a.title! < b.title!) return -1
+      return 0
+    })
+
+    expect(body.issues).toEqual(sortedIssues)
+  })
+})
+
+
+describe("GET /api/issues/plots/:plot_id?order=", () => {
+
+  test("GET:400 Responds with an error when passed an invalid order value", async () => {
+
+    const { body } = await request(app)
+      .get("/api/issues/plots/1?order=foobar")
       .set("Authorization", `Bearer ${token}`)
       .expect(400)
 

--- a/src/__tests__/issues.test.ts
+++ b/src/__tests__/issues.test.ts
@@ -345,3 +345,57 @@ describe("GET /api/issues/plots/:plot_id?limit=", () => {
     })
   })
 })
+
+
+describe("GET /api/issues/plots/:plot_id?page=", () => {
+
+  test("GET:200 Responds with an array of issue objects associated with the plot beginning from the page set in the query parameter", async () => {
+
+    const { body } = await request(app)
+      .get("/api/issues/plots/1?limit=2&page=2")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+
+    expect(body.issues.map((issue: ExtendedIssue) => {
+      return issue.issue_id
+    })).toEqual([1])
+  })
+
+  test("GET:200 The page defaults to page one", async () => {
+
+    const { body } = await request(app)
+      .get("/api/issues/plots/1?limit=2")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+
+    expect(body.issues.map((issue: ExtendedIssue) => {
+      return issue.issue_id
+    })).toEqual([3, 2])
+  })
+
+  test("GET:400 Responds with an error when the value of page is not a positive integer", async () => {
+
+    const { body } = await request(app)
+      .get("/api/issues/plots/1?limit=2&page=two")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Bad Request",
+      details: "Value must be a positive integer"
+    })
+  })
+
+  test("GET:404 Responds with an error when the page cannot be found", async () => {
+
+    const { body } = await request(app)
+      .get("/api/issues/plots/1?limit=2&page=3")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(404)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Not Found",
+      details: "Page not found"
+    })
+  })
+})

--- a/src/__tests__/issues.test.ts
+++ b/src/__tests__/issues.test.ts
@@ -308,3 +308,40 @@ describe("GET /api/issues/plots/:plot_id?order=", () => {
     })
   })
 })
+
+
+describe("GET /api/issues/plots/:plot_id?limit=", () => {
+
+  test("GET:200 Responds with a limited array of issue objects associated with the plot", async () => {
+
+    const { body } = await request(app)
+      .get("/api/issues/plots/1?limit=2")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+
+    expect(body.issues).toHaveLength(2)
+  })
+
+  test("GET:200 Responds with an array of all issues associated with the plot when the limit exceeds the total number of results", async () => {
+
+    const { body } = await request(app)
+      .get("/api/issues/plots/1?limit=20")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+
+    expect(body.issues).toHaveLength(3)
+  })
+
+  test("GET:400 Responds with an error when the value of limit is not a positive integer", async () => {
+
+    const { body } = await request(app)
+      .get("/api/issues/plots/1?limit=foobar")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Bad Request",
+      details: "Value must be a positive integer"
+    })
+  })
+})

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -41,7 +41,7 @@ describe("GET /api/plots/users/:owner_id", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedPlots = [...body.plots].sort((a: ExtendedPlot, b: ExtendedPlot) => {
+    const sortedPlots: ExtendedPlot[] = [...body.plots].sort((a: ExtendedPlot, b: ExtendedPlot) => {
       if (a.plot_id! < b.plot_id!) return 1
       if (a.plot_id! > b.plot_id!) return -1
       return 0
@@ -259,7 +259,7 @@ describe("GET /api/plots/users/:owner_id?sort=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedPlots = [...body.plots].sort((a: ExtendedPlot, b: ExtendedPlot) => {
+    const sortedPlots: ExtendedPlot[] = [...body.plots].sort((a: ExtendedPlot, b: ExtendedPlot) => {
       if (a.name! > b.name!) return 1
       if (a.name! < b.name!) return -1
       return 0
@@ -646,7 +646,7 @@ describe("GET /api/plots/users/:owner_id/pinned", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedPlots = [...body.plots].sort((a: Plot, b: Plot) => {
+    const sortedPlots: ExtendedPlot[] = [...body.plots].sort((a: Plot, b: Plot) => {
       if (a.name! > b.name!) return 1
       if (a.name! < b.name!) return -1
       return 0

--- a/src/__tests__/subdivisions.test.ts
+++ b/src/__tests__/subdivisions.test.ts
@@ -41,7 +41,7 @@ describe("GET /api/subdivisions/plots/:plot_id", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedSubdivisions = [...body.subdivisions].sort((a: ExtendedSubdivision, b: ExtendedSubdivision) => {
+    const sortedSubdivisions: ExtendedSubdivision[] = [...body.subdivisions].sort((a: ExtendedSubdivision, b: ExtendedSubdivision) => {
       if (a.subdivision_id! < b.subdivision_id!) return 1
       if (a.subdivision_id! > b.subdivision_id!) return -1
       return 0
@@ -247,7 +247,7 @@ describe("GET /api/subdivisions/plots/:plot_id?sort=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedSubdivisions = [...body.subdivisions].sort((a: ExtendedSubdivision, b: ExtendedSubdivision) => {
+    const sortedSubdivisions: ExtendedSubdivision[] = [...body.subdivisions].sort((a: ExtendedSubdivision, b: ExtendedSubdivision) => {
       if (a.name! > b.name!) return 1
       if (a.name! < b.name!) return -1
       return 0

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -39,7 +39,7 @@ describe("GET /api/users", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedUsers = [...body.users].sort((a: SecureUser, b: SecureUser) => {
+    const sortedUsers: SecureUser[] = [...body.users].sort((a: SecureUser, b: SecureUser) => {
       if (a.user_id! > b.user_id!) return 1
       if (a.user_id! < b.user_id!) return -1
       return 0
@@ -157,7 +157,7 @@ describe("GET /api/users?sort=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedUsers = [...body.users].sort((a: SecureUser, b: SecureUser) => {
+    const sortedUsers: SecureUser[] = [...body.users].sort((a: SecureUser, b: SecureUser) => {
       if (a.email > b.email) return 1
       if (a.email < b.email) return -1
       return 0
@@ -175,7 +175,7 @@ describe("GET /api/users?sort=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedUsers = [...body.users].sort((a: SecureUser, b: SecureUser) => {
+    const sortedUsers: SecureUser[] = [...body.users].sort((a: SecureUser, b: SecureUser) => {
       if (a.surname > b.surname) return 1
       if (a.surname < b.surname) return -1
       return 0
@@ -210,7 +210,7 @@ describe("GET /api/users?role=&sort=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedUsers = [...body.users].sort((a: SecureUser, b: SecureUser) => {
+    const sortedUsers: SecureUser[] = [...body.users].sort((a: SecureUser, b: SecureUser) => {
       if (a.first_name > b.first_name) return 1
       if (a.first_name < b.first_name) return -1
       return 0
@@ -236,7 +236,7 @@ describe("GET /api/users?order=", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    const sortedUsers = [...body.users].sort((a: SecureUser, b: SecureUser) => {
+    const sortedUsers: SecureUser[] = [...body.users].sort((a: SecureUser, b: SecureUser) => {
       if (a.user_id! < b.user_id!) return 1
       if (a.user_id! > b.user_id!) return -1
       return 0

--- a/src/controllers/issues-controllers.ts
+++ b/src/controllers/issues-controllers.ts
@@ -10,8 +10,8 @@ export const getIssuesByPlotId = async (req: ExtendedRequest, res: Response, nex
   const { plot_id } = req.params
 
   try {
-    const issues = await selectIssuesByPlotId(authUserId, +plot_id, req.query)
-    res.status(200).send({ issues })
+    const [issues, count] = await selectIssuesByPlotId(authUserId, +plot_id, req.query)
+    res.status(200).send({ issues, count })
   } catch (err) {
     next(err)
   }

--- a/src/models/issues-models.ts
+++ b/src/models/issues-models.ts
@@ -57,7 +57,7 @@ export const selectIssuesByPlotId = async (
   let countQuery = `
   SELECT COUNT(issue_id)::INT
   FROM issues
-  WHERE issue_id = $1
+  WHERE plot_id = $1
   `
 
   if (is_critical) {

--- a/src/models/issues-models.ts
+++ b/src/models/issues-models.ts
@@ -76,9 +76,9 @@ export const selectIssuesByPlotId = async (
   }
 
   query += format(`
-  ORDER BY %s %s, issues.title
-  LIMIT %s
-  `, sort, order, limit)
+    ORDER BY %s %s, issues.title
+    LIMIT %s
+    `, sort, order, limit)
 
   const result = await db.query(query, [plot_id])
 

--- a/src/models/issues-models.ts
+++ b/src/models/issues-models.ts
@@ -11,7 +11,9 @@ export const selectIssuesByPlotId = async (
   plot_id: number,
   {
     is_critical,
-    is_resolved
+    is_resolved,
+    sort = "issue_id",
+    order = "desc"
   }: QueryString.ParsedQs
 ): Promise<ExtendedIssue[]> => {
 
@@ -20,6 +22,10 @@ export const selectIssuesByPlotId = async (
   const owner_id = await fetchPlotOwnerId(plot_id)
 
   await verifyPermission(authUserId, owner_id)
+
+  await verifyQueryValue(["issue_id", "title"], sort as string)
+
+  await verifyQueryValue(["asc", "desc"], order as string)
 
   let query = `
   SELECT
@@ -60,8 +66,12 @@ export const selectIssuesByPlotId = async (
   GROUP BY issues.issue_id, subdivisions.name
   `
 
+  if (sort === "title") {
+    order = "asc"
+  }
+
   query += `
-  ORDER BY issues.issue_id DESC, issues.title
+  ORDER BY ${sort} ${order}, issues.title
   `
 
   const result = await db.query(`${query};`, [plot_id])

--- a/src/models/issues-models.ts
+++ b/src/models/issues-models.ts
@@ -13,7 +13,7 @@ export const selectIssuesByPlotId = async (
     is_critical,
     is_resolved,
     sort = "issue_id",
-    order = "desc"
+    order
   }: QueryString.ParsedQs
 ): Promise<ExtendedIssue[]> => {
 
@@ -25,7 +25,9 @@ export const selectIssuesByPlotId = async (
 
   await verifyQueryValue(["issue_id", "title"], sort as string)
 
-  await verifyQueryValue(["asc", "desc"], order as string)
+  if (order) {
+    await verifyQueryValue(["asc", "desc"], order as string)
+  }
 
   let query = `
   SELECT
@@ -66,8 +68,8 @@ export const selectIssuesByPlotId = async (
   GROUP BY issues.issue_id, subdivisions.name
   `
 
-  if (sort === "title") {
-    order = "asc"
+  if (!order) {
+    sort === "issue_id" ? order = "desc" : order = "asc"
   }
 
   query += `

--- a/src/models/issues-models.ts
+++ b/src/models/issues-models.ts
@@ -13,11 +13,14 @@ export const selectIssuesByPlotId = async (
     is_critical,
     is_resolved,
     sort = "issue_id",
-    order
+    order,
+    limit = "10"
   }: QueryString.ParsedQs
 ): Promise<ExtendedIssue[]> => {
 
   await verifyValueIsPositiveInt(plot_id)
+
+  await verifyValueIsPositiveInt(+limit)
 
   const owner_id = await fetchPlotOwnerId(plot_id)
 
@@ -53,7 +56,7 @@ export const selectIssuesByPlotId = async (
 
     query += format(`
       AND issues.is_critical = %L
-      `, `${is_critical}`)
+      `, is_critical)
   }
 
   if (is_resolved) {
@@ -61,7 +64,7 @@ export const selectIssuesByPlotId = async (
 
     query += format(`
       AND issues.is_resolved = %L
-      `, `${is_resolved}`)
+      `, is_resolved)
   }
 
   query += `
@@ -74,6 +77,7 @@ export const selectIssuesByPlotId = async (
 
   query += `
   ORDER BY ${sort} ${order}, issues.title
+  LIMIT ${limit}
   `
 
   const result = await db.query(`${query};`, [plot_id])

--- a/src/models/issues-models.ts
+++ b/src/models/issues-models.ts
@@ -75,12 +75,12 @@ export const selectIssuesByPlotId = async (
     sort === "issue_id" ? order = "desc" : order = "asc"
   }
 
-  query += `
-  ORDER BY ${sort} ${order}, issues.title
-  LIMIT ${limit}
-  `
+  query += format(`
+  ORDER BY %s %s, issues.title
+  LIMIT %s
+  `, sort, order, limit)
 
-  const result = await db.query(`${query};`, [plot_id])
+  const result = await db.query(query, [plot_id])
 
   return result.rows
 }

--- a/src/routes/issues-router.ts
+++ b/src/routes/issues-router.ts
@@ -16,7 +16,7 @@ issuesRouter.route("/issues/plots/:plot_id")
  *    security:
  *      - bearerAuth: []
  *    summary: Retrieve a plot's issues
- *    description: Responds with an array of issue objects. If a parameter is invalid, the server responds with an error. Permission is denied when the plot does not belong to the user.
+ *    description: Responds with an array of issue objects. Results can be filtered by is_critical or is_resolved and sorted by issue_id or title. If a parameter is invalid, the server responds with an error. Permission is denied when the plot does not belong to the user.
  *    tags: [Issues]
  *    parameters:
  *      - in: path
@@ -47,6 +47,16 @@ issuesRouter.route("/issues/plots/:plot_id")
  *          enum:
  *            - asc
  *            - desc
+ *      - in: query
+ *        name: limit
+ *        schema:
+ *          type: integer
+ *        default: 10
+ *      - in: query
+ *        name: page
+ *        schema:
+ *          type: integer
+ *        default: 1
  *    responses:
  *      200:
  *        description: OK

--- a/src/routes/issues-router.ts
+++ b/src/routes/issues-router.ts
@@ -32,6 +32,21 @@ issuesRouter.route("/issues/plots/:plot_id")
  *        name: is_resolved
  *        schema:
  *          type: boolean
+ *      - in: query
+ *        name: sort
+ *        schema:
+ *          type: string
+ *          enum:
+ *            - issue_id
+ *            - title
+ *        default: issue_id
+ *      - in: query
+ *        name: order
+ *        schema:
+ *          type: string
+ *          enum:
+ *            - asc
+ *            - desc
  *    responses:
  *      200:
  *        description: OK


### PR DESCRIPTION
### Summary

- Extended query in `selectIssuesByPlotId` to allow results to be sorted
- Added tests for `GET /api/issues/plots/:plot_id?sort=`
- Added tests for `GET /api/issues/plots/:plot_id?is_critical=&sort=`
- Added tests for `GET /api/issues/plots/:plot_id?order=`
- Extended query in `selectIssuesByPlotId` to allow results to be limited
- Added tests for `GET /api/issues/plots/:plot_id?limit=`
- Extended query in `selectIssuesByPlotId` to allow results to be paginated
- Added tests for `GET /api/issues/plots/:plot_id?page=`
- Added `countQuery` to `selectIssuesByPlotId`
- Updated controller to receive and send `count`