### PR TITLE
Query fixes

### DIFF
--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -307,10 +307,10 @@ describe("GET /api/crops/plots/:plot_id?sort=", () => {
 
 describe("GET /api/crops/plots/:plot_id?name=&sort=", () => {
 
-  test("GET:200 Responds with an array of crop objects filtered by name and sorted by name in ascending order", async () => {
+  test("GET:200 Responds with an array of crop objects filtered by name and sorted by crop_id in descending order", async () => {
 
     const { body } = await request(app)
-      .get("/api/crops/plots/1?name=ca&sort=name")
+      .get("/api/crops/plots/1?name=ca&sort=crop_id")
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
@@ -319,8 +319,8 @@ describe("GET /api/crops/plots/:plot_id?name=&sort=", () => {
     }
 
     const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
-      if (a.name > b.name) return 1
-      if (a.name < b.name) return -1
+      if (a.crop_id! < b.crop_id!) return 1
+      if (a.crop_id! > b.crop_id!) return -1
       return 0
     })
 
@@ -959,10 +959,10 @@ describe("GET /api/crops/subdivisions/:subdivision_id?sort=", () => {
 
 describe("GET /api/crops/subdivisions/:subdivision_id?name=&sort=", () => {
 
-  test("GET:200 Responds with an array of crop objects filtered by name and sorted by name in ascending order", async () => {
+  test("GET:200 Responds with an array of crop objects filtered by name and sorted by crop_id in ascending order", async () => {
 
     const { body } = await request(app)
-      .get("/api/crops/subdivisions/1?name=car&sort=name")
+      .get("/api/crops/subdivisions/1?name=car&sort=crop_id")
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
@@ -971,8 +971,8 @@ describe("GET /api/crops/subdivisions/:subdivision_id?name=&sort=", () => {
     }
 
     const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
-      if (a.name > b.name) return 1
-      if (a.name < b.name) return -1
+      if (a.crop_id! < b.crop_id!) return 1
+      if (a.crop_id! > b.crop_id!) return -1
       return 0
     })
 

--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -36,7 +36,7 @@ afterAll(async () => {
 
 describe("GET /api/crops/plots/:plot_id", () => {
 
-  test("GET:200 Responds with an array of crop objects sorted by crop_id in descending order", async () => {
+  test("GET:200 Responds with an array of crop objects sorted by name in ascending order", async () => {
 
     const { body } = await request(app)
       .get("/api/crops/plots/1")
@@ -44,8 +44,8 @@ describe("GET /api/crops/plots/:plot_id", () => {
       .expect(200)
 
     const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
-      if (a.crop_id! < b.crop_id!) return 1
-      if (a.crop_id! > b.crop_id!) return -1
+      if (a.name! > b.name!) return 1
+      if (a.name! < b.name!) return -1
       return 0
     })
 
@@ -268,7 +268,7 @@ describe("GET /api/crops/plots/:plot_id?sort=", () => {
     expect(body.count).toBe(3)
   })
 
-  test("GET:200 Responds with an array of crop objects sorted by harvest_date in descending order while filtering out null values", async () => {
+  test("GET:200 Responds with an array of crop objects sorted by harvest_date in ascending order while filtering out null values", async () => {
 
     const { body } = await request(app)
       .get("/api/crops/plots/1?sort=harvest_date")
@@ -280,8 +280,8 @@ describe("GET /api/crops/plots/:plot_id?sort=", () => {
     }
 
     const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
-      if (a.harvest_date! < b.harvest_date!) return 1
-      if (a.harvest_date! > b.harvest_date!) return -1
+      if (a.harvest_date! > b.harvest_date!) return 1
+      if (a.harvest_date! < b.harvest_date!) return -1
       return 0
     })
 
@@ -329,7 +329,7 @@ describe("GET /api/crops/plots/:plot_id?name=&sort=", () => {
     expect(body.count).toBe(3)
   })
 
-  test("GET:200 Responds with an array of crop objects filtered by name and sorted by harvest_date in descending order while filtering out null values", async () => {
+  test("GET:200 Responds with an array of crop objects filtered by name and sorted by harvest_date in ascending order while filtering out null values", async () => {
 
     const { body } = await request(app)
       .get("/api/crops/plots/1?name=ca&sort=harvest_date")
@@ -341,8 +341,8 @@ describe("GET /api/crops/plots/:plot_id?name=&sort=", () => {
     }
 
     const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
-      if (a.harvest_date! < b.harvest_date!) return 1
-      if (a.harvest_date! > b.harvest_date!) return -1
+      if (a.harvest_date! > b.harvest_date!) return 1
+      if (a.harvest_date! < b.harvest_date!) return -1
       return 0
     })
 
@@ -421,8 +421,8 @@ describe("GET /api/crops/plots/:plot_id?page=", () => {
       .expect(200)
 
     expect(body.crops.map((crop: ExtendedCrop) => {
-      return crop.crop_id
-    })).toEqual([2, 1])
+      return crop.name
+    })).toEqual(["Carrot", "Pecan"])
 
     expect(body.count).toBe(4)
   })
@@ -435,8 +435,8 @@ describe("GET /api/crops/plots/:plot_id?page=", () => {
       .expect(200)
 
     expect(body.crops.map((crop: ExtendedCrop) => {
-      return crop.crop_id
-    })).toEqual([4, 3])
+      return crop.name
+    })).toEqual(["Apple", "Cabbage"])
 
     expect(body.count).toBe(4)
   })
@@ -449,8 +449,8 @@ describe("GET /api/crops/plots/:plot_id?page=", () => {
       .expect(200)
 
     expect(body.crops.map((crop: ExtendedCrop) => {
-      return crop.crop_id
-    })).toEqual([1])
+      return crop.name
+    })).toEqual(["Pecan"])
 
     expect(body.count).toBe(4)
   })

--- a/src/__tests__/crops.test.ts
+++ b/src/__tests__/crops.test.ts
@@ -228,16 +228,16 @@ describe("GET /api/crops/plots/:plot_id?name=&category=", () => {
 
 describe("GET /api/crops/plots/:plot_id?sort=", () => {
 
-  test("GET:200 Responds with an array of crop objects sorted by name in ascending order", async () => {
+  test("GET:200 Responds with an array of crop objects sorted by crop_id in descending order", async () => {
 
     const { body } = await request(app)
-      .get("/api/crops/plots/1?sort=name")
+      .get("/api/crops/plots/1?sort=crop_id")
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
     const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
-      if (a.name > b.name) return 1
-      if (a.name < b.name) return -1
+      if (a.crop_id! < b.crop_id!) return 1
+      if (a.crop_id! > b.crop_id!) return -1
       return 0
     })
 
@@ -689,7 +689,7 @@ describe("POST /api/crops/plots/:plot_id", () => {
 
 describe("GET /api/crops/subdivisions/:subdivision_id", () => {
 
-  test("GET:200 Responds with an array of crop objects sorted by crop_id in descending order", async () => {
+  test("GET:200 Responds with an array of crop objects sorted by name in ascending order", async () => {
 
     const { body } = await request(app)
       .get("/api/crops/subdivisions/1")
@@ -697,8 +697,8 @@ describe("GET /api/crops/subdivisions/:subdivision_id", () => {
       .expect(200)
 
     const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
-      if (a.crop_id! < b.crop_id!) return 1
-      if (a.crop_id! > b.crop_id!) return -1
+      if (a.name! > b.name!) return 1
+      if (a.name! < b.name!) return -1
       return 0
     })
 
@@ -880,16 +880,16 @@ describe("GET /api/crops/subdivisions/:subdivision_id?name=&category=", () => {
 
 describe("GET /api/crops/subdivisions/:subdivision_id?sort=", () => {
 
-  test("GET:200 Responds with an array of crop objects sorted by name in ascending order", async () => {
+  test("GET:200 Responds with an array of crop objects sorted by crop_id in descending order", async () => {
 
     const { body } = await request(app)
-      .get("/api/crops/subdivisions/1?sort=name")
+      .get("/api/crops/subdivisions/1?sort=crop_id")
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
     const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
-      if (a.name > b.name) return 1
-      if (a.name < b.name) return -1
+      if (a.crop_id! < b.crop_id!) return 1
+      if (a.crop_id! > b.crop_id!) return -1
       return 0
     })
 
@@ -920,7 +920,7 @@ describe("GET /api/crops/subdivisions/:subdivision_id?sort=", () => {
     expect(body.count).toBe(2)
   })
 
-  test("GET:200 Responds with an array of crop objects sorted by harvest_date in descending order while filtering out null values", async () => {
+  test("GET:200 Responds with an array of crop objects sorted by harvest_date in ascending order while filtering out null values", async () => {
 
     const { body } = await request(app)
       .get("/api/crops/subdivisions/1?sort=harvest_date")
@@ -932,8 +932,8 @@ describe("GET /api/crops/subdivisions/:subdivision_id?sort=", () => {
     }
 
     const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
-      if (a.harvest_date! < b.harvest_date!) return 1
-      if (a.harvest_date! > b.harvest_date!) return -1
+      if (a.harvest_date! > b.harvest_date!) return 1
+      if (a.harvest_date! < b.harvest_date!) return -1
       return 0
     })
 
@@ -981,7 +981,7 @@ describe("GET /api/crops/subdivisions/:subdivision_id?name=&sort=", () => {
     expect(body.count).toBe(1)
   })
 
-  test("GET:200 Responds with an array of crop objects filtered by name and sorted by harvest_date in descending order while filtering out null values", async () => {
+  test("GET:200 Responds with an array of crop objects filtered by name and sorted by harvest_date in ascending order while filtering out null values", async () => {
 
     const { body } = await request(app)
       .get("/api/crops/subdivisions/1?name=car&sort=harvest_date")
@@ -993,8 +993,8 @@ describe("GET /api/crops/subdivisions/:subdivision_id?name=&sort=", () => {
     }
 
     const sortedCrops: ExtendedCrop[] = [...body.crops].sort((a: ExtendedCrop, b: ExtendedCrop) => {
-      if (a.harvest_date! < b.harvest_date!) return 1
-      if (a.harvest_date! > b.harvest_date!) return -1
+      if (a.harvest_date! > b.harvest_date!) return 1
+      if (a.harvest_date! < b.harvest_date!) return -1
       return 0
     })
 
@@ -1073,8 +1073,8 @@ describe("GET /api/crops/subdivisions/:subdivision_id?page=", () => {
       .expect(200)
 
     expect(body.crops.map((crop: ExtendedCrop) => {
-      return crop.crop_id
-    })).toEqual([1])
+      return crop.name
+    })).toEqual(["Pecan"])
 
     expect(body.count).toBe(2)
   })
@@ -1087,8 +1087,8 @@ describe("GET /api/crops/subdivisions/:subdivision_id?page=", () => {
       .expect(200)
 
     expect(body.crops.map((crop: ExtendedCrop) => {
-      return crop.crop_id
-    })).toEqual([4])
+      return crop.name
+    })).toEqual(["Carrot"])
 
     expect(body.count).toBe(2)
   })

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -34,7 +34,7 @@ afterAll(async () => {
 
 describe("GET /api/plots/users/:owner_id", () => {
 
-  test("GET:200 Responds with an array of plot objects sorted by plot_id in descending order", async () => {
+  test("GET:200 Responds with an array of plot objects sorted by name in ascending order", async () => {
 
     const { body } = await request(app)
       .get("/api/plots/users/1")
@@ -42,8 +42,8 @@ describe("GET /api/plots/users/:owner_id", () => {
       .expect(200)
 
     const sortedPlots: ExtendedPlot[] = [...body.plots].sort((a: ExtendedPlot, b: ExtendedPlot) => {
-      if (a.plot_id! < b.plot_id!) return 1
-      if (a.plot_id! > b.plot_id!) return -1
+      if (a.name > b.name) return 1
+      if (a.name < b.name) return -1
       return 0
     })
 
@@ -252,16 +252,16 @@ describe("GET /api/plots/users/:owner_id?type=&name=", () => {
 
 describe("GET /api/plots/users/:owner_id?sort=", () => {
 
-  test("GET:200 Responds with an array of plot objects sorted by name in ascending order", async () => {
+  test("GET:200 Responds with an array of plot objects sorted by plot_id in descending order", async () => {
 
     const { body } = await request(app)
-      .get("/api/plots/users/1?sort=name")
+      .get("/api/plots/users/1?sort=plot_id")
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
     const sortedPlots: ExtendedPlot[] = [...body.plots].sort((a: ExtendedPlot, b: ExtendedPlot) => {
-      if (a.name! > b.name!) return 1
-      if (a.name! < b.name!) return -1
+      if (a.plot_id! < b.plot_id!) return 1
+      if (a.plot_id! > b.plot_id!) return -1
       return 0
     })
 
@@ -353,8 +353,8 @@ describe("GET /api/plots/users/:owner_id?page=", () => {
       .expect(200)
 
     expect(body.plots.map((crop: ExtendedPlot) => {
-      return crop.plot_id
-    })).toEqual([1])
+      return crop.name
+    })).toEqual(["John's New Allotment"])
 
     expect(body.count).toBe(3)
   })
@@ -367,8 +367,8 @@ describe("GET /api/plots/users/:owner_id?page=", () => {
       .expect(200)
 
     expect(body.plots.map((crop: ExtendedPlot) => {
-      return crop.plot_id
-    })).toEqual([4, 3])
+      return crop.name
+    })).toEqual(["John's Allotment", "John's Garden"])
 
     expect(body.count).toBe(3)
   })

--- a/src/__tests__/subdivisions.test.ts
+++ b/src/__tests__/subdivisions.test.ts
@@ -34,7 +34,7 @@ afterAll(async () => {
 
 describe("GET /api/subdivisions/plots/:plot_id", () => {
 
-  test("GET:200 Responds with an array of subdivision objects sorted by subdivision_id in descending order", async () => {
+  test("GET:200 Responds with an array of subdivision objects sorted by type in ascending order", async () => {
 
     const { body } = await request(app)
       .get("/api/subdivisions/plots/1")
@@ -42,8 +42,8 @@ describe("GET /api/subdivisions/plots/:plot_id", () => {
       .expect(200)
 
     const sortedSubdivisions: ExtendedSubdivision[] = [...body.subdivisions].sort((a: ExtendedSubdivision, b: ExtendedSubdivision) => {
-      if (a.subdivision_id! < b.subdivision_id!) return 1
-      if (a.subdivision_id! > b.subdivision_id!) return -1
+      if (a.type > b.type) return 1
+      if (a.type < b.type) return -1
       return 0
     })
 
@@ -341,8 +341,8 @@ describe("GET /api/subdivisions/plots/:plot_id?page=", () => {
       .expect(200)
 
     expect(body.subdivisions.map((subdivision: ExtendedSubdivision) => {
-      return subdivision.subdivision_id
-    })).toEqual([1])
+      return subdivision.name
+    })).toEqual(["Woody Herbs"])
 
     expect(body.count).toBe(3)
   })
@@ -355,8 +355,8 @@ describe("GET /api/subdivisions/plots/:plot_id?page=", () => {
       .expect(200)
 
     expect(body.subdivisions.map((subdivision: ExtendedSubdivision) => {
-      return subdivision.subdivision_id
-    })).toEqual([3, 2])
+      return subdivision.name
+    })).toEqual(["Onion Bed", "Root Vegetable Bed"])
 
     expect(body.count).toBe(3)
   })

--- a/src/models/crops-models.ts
+++ b/src/models/crops-models.ts
@@ -93,13 +93,13 @@ export const selectCropsByPlotId = async (
   }
 
   if (sort === "date_planted" || sort === "harvest_date") {
-    query += `
-    AND crops.${sort} IS NOT NULL
-    `
+    query += format(`
+      AND crops.%I IS NOT NULL
+      `, sort)
 
-    countQuery += `
-    AND crops.${sort} IS NOT NULL
-    `
+    countQuery += format(`
+      AND crops.%I IS NOT NULL
+      `, sort)
   }
 
   query += `
@@ -258,13 +258,13 @@ export const selectCropsBySubdivisionId = async (
   }
 
   if (sort === "date_planted" || sort === "harvest_date") {
-    query += `
-    AND crops.${sort} IS NOT NULL
-    `
+    query += format(`
+      AND crops.%I IS NOT NULL
+      `, sort)
 
-    countQuery += `
-    AND crops.${sort} IS NOT NULL
-    `
+    countQuery += format(`
+      AND crops.%I IS NOT NULL
+      `, sort)
   }
 
   query += `

--- a/src/models/crops-models.ts
+++ b/src/models/crops-models.ts
@@ -72,6 +72,7 @@ export const selectCropsByPlotId = async (
     query += format(`
       AND crops.name ILIKE %L
       `, `%${name}%`)
+
     countQuery += format(`
       AND crops.name ILIKE %L
       `, `%${name}%`)
@@ -81,6 +82,7 @@ export const selectCropsByPlotId = async (
     query += format(`
       AND crops.category ILIKE %L
       `, category)
+
     countQuery += format(`
       AND crops.category ILIKE %L
       `, category)
@@ -90,6 +92,7 @@ export const selectCropsByPlotId = async (
     query += `
     AND crops.${sort} IS NOT NULL
     `
+
     countQuery += `
     AND crops.${sort} IS NOT NULL
     `
@@ -103,17 +106,17 @@ export const selectCropsByPlotId = async (
     order = "asc"
   }
 
-  query += `
-  ORDER BY ${sort} ${order}, crops.name
-  LIMIT ${limit}
-  OFFSET ${(+page - 1) * +limit}
-  `
+  query += format(`
+    ORDER BY %s %s, crops.name
+    LIMIT %L
+    OFFSET %L
+    `, sort, order, limit, (+page - 1) * +limit)
 
-  const result = await db.query(`${query};`, [plot_id])
+  const result = await db.query(query, [plot_id])
 
   await verifyPagination(+page, result.rows.length)
 
-  const countResult = await db.query(`${countQuery};`, [plot_id])
+  const countResult = await db.query(countQuery, [plot_id])
 
   return Promise.all([result.rows, countResult.rows[0].count])
 }

--- a/src/models/crops-models.ts
+++ b/src/models/crops-models.ts
@@ -12,8 +12,8 @@ export const selectCropsByPlotId = async (
   {
     name,
     category,
-    sort = "crop_id",
-    order = "desc",
+    sort = "name",
+    order,
     limit = "10",
     page = "1"
   }: QueryString.ParsedQs
@@ -31,7 +31,11 @@ export const selectCropsByPlotId = async (
 
   await verifyQueryValue(["crop_id", "name", "date_planted", "harvest_date"], sort as string)
 
-  await verifyQueryValue(["asc", "desc"], order as string)
+  if (order) {
+    await verifyQueryValue(["asc", "desc"], order as string)
+  } else {
+    sort === "name" || sort === "harvest_date" ? order = "asc" : order = "desc"
+  }
 
   const isValidCropCategory = await confirmCropCategoryIsValid(category as string, true)
 
@@ -101,10 +105,6 @@ export const selectCropsByPlotId = async (
   query += `
   GROUP BY crops.crop_id, subdivisions.name
   `
-
-  if (sort === "name") {
-    order = "asc"
-  }
 
   query += format(`
     ORDER BY %s %s, crops.name

--- a/src/models/issues-models.ts
+++ b/src/models/issues-models.ts
@@ -34,7 +34,7 @@ export const selectIssuesByPlotId = async (
   if (order) {
     await verifyQueryValue(["asc", "desc"], order as string)
   } else {
-    sort === "issue_id" ? order = "desc" : order = "asc"
+    sort === "title" ? order = "asc" : order = "desc"
   }
 
   let query = `

--- a/src/models/issues-models.ts
+++ b/src/models/issues-models.ts
@@ -33,6 +33,8 @@ export const selectIssuesByPlotId = async (
 
   if (order) {
     await verifyQueryValue(["asc", "desc"], order as string)
+  } else {
+    sort === "issue_id" ? order = "desc" : order = "asc"
   }
 
   let query = `
@@ -87,10 +89,6 @@ export const selectIssuesByPlotId = async (
   query += `
   GROUP BY issues.issue_id, subdivisions.name
   `
-
-  if (!order) {
-    sort === "issue_id" ? order = "desc" : order = "asc"
-  }
 
   query += format(`
     ORDER BY %s %s, issues.title

--- a/src/models/users-models.ts
+++ b/src/models/users-models.ts
@@ -57,6 +57,7 @@ export const selectAllUsers = async (
     query += format(`
       AND users.role::VARCHAR ILIKE %L
       `, role)
+
     countQuery += format(`
       AND users.role::VARCHAR ILIKE %L
       `, role)
@@ -68,22 +69,23 @@ export const selectAllUsers = async (
     query += format(`
       AND users.unit_system::VARCHAR ILIKE %L
       `, unit_system)
+
     countQuery += format(`
       AND users.unit_system::VARCHAR ILIKE %L
       `, unit_system)
   }
 
-  query += `
-  ORDER BY ${sort} ${order}
-  LIMIT ${limit}
-  OFFSET ${(+page - 1) * +limit}
-  `
+  query += format(`
+    ORDER BY %s %s
+    LIMIT %L
+    OFFSET %L
+    `, sort, order, limit, (+page - 1) * +limit)
 
-  const result = await db.query(`${query};`)
+  const result = await db.query(query)
 
   await verifyPagination(+page, result.rows.length)
 
-  const countResult = await db.query(`${countQuery};`)
+  const countResult = await db.query(countQuery)
 
   return Promise.all([result.rows, countResult.rows[0].count])
 }

--- a/src/routes/crops-router.ts
+++ b/src/routes/crops-router.ts
@@ -36,12 +36,19 @@ cropsRouter.route("/crops/plots/:plot_id")
  *        name: sort
  *        schema:
  *          type: string
+ *          enum:
+ *            - crop_id
+ *            - date_planted
+ *            - harvest_date
+ *            - name
  *        default: crop_id
  *      - in: query
  *        name: order
  *        schema:
  *          type: string
- *        default: desc
+ *          enum:
+ *            - asc
+ *            - desc
  *      - in: query
  *        name: limit
  *        schema:

--- a/src/routes/crops-router.ts
+++ b/src/routes/crops-router.ts
@@ -41,7 +41,7 @@ cropsRouter.route("/crops/plots/:plot_id")
  *            - date_planted
  *            - harvest_date
  *            - name
- *        default: crop_id
+ *        default: name
  *      - in: query
  *        name: order
  *        schema:
@@ -191,12 +191,19 @@ cropsRouter.route("/crops/subdivisions/:subdivision_id")
  *        name: sort
  *        schema:
  *          type: string
- *        default: crop_id
+ *          enum:
+ *            - crop_id
+ *            - date_planted
+ *            - harvest_date
+ *            - name
+ *        default: name
  *      - in: query
  *        name: order
  *        schema:
  *          type: string
- *        default: desc
+ *          enum:
+ *            - asc
+ *            - desc
  *      - in: query
  *        name: limit
  *        schema:

--- a/src/routes/plots-router.ts
+++ b/src/routes/plots-router.ts
@@ -39,7 +39,7 @@ plotsRouter.route("/plots/users/:owner_id")
  *          enum:
  *            - name
  *            - plot_id
- *        default: plot_id
+ *        default: name
  *      - in: query
  *        name: order
  *        schema:

--- a/src/routes/plots-router.ts
+++ b/src/routes/plots-router.ts
@@ -36,12 +36,17 @@ plotsRouter.route("/plots/users/:owner_id")
  *        name: sort
  *        schema:
  *          type: string
+ *          enum:
+ *            - name
+ *            - plot_id
  *        default: plot_id
  *      - in: query
  *        name: order
  *        schema:
  *          type: string
- *        default: desc
+ *          enum:
+ *            - asc
+ *            - desc
  *      - in: query
  *        name: limit
  *        schema:

--- a/src/routes/subdivisions-router.ts
+++ b/src/routes/subdivisions-router.ts
@@ -16,7 +16,7 @@ subdivisionsRouter.route("/subdivisions/plots/:plot_id")
  *    security:
  *      - bearerAuth: []
  *    summary: Retrieve subdivisions of a plot
- *    description: Responds with an array of subdivision objects. Results can be filtered by name and sorted by subdivision_id or name. If a parameter is invalid, the server responds with an error. Permission is denied when the plot does not belong to the user.
+ *    description: Responds with an array of subdivision objects. Results can be filtered by name or type and sorted by subdivision_id, name, or type. If a parameter is invalid, the server responds with an error. Permission is denied when the plot does not belong to the user.
  *    tags: [Subdivisions]
  *    parameters:
  *      - in: path
@@ -36,12 +36,18 @@ subdivisionsRouter.route("/subdivisions/plots/:plot_id")
  *        name: sort
  *        schema:
  *          type: string
- *        default: subdivision_id
+ *          enum:
+ *            - subdivision_id
+ *            - name
+ *            - type
+ *        default: type
  *      - in: query
  *        name: order
  *        schema:
  *          type: string
- *        default: desc
+ *          enum:
+ *            - asc
+ *            - desc
  *      - in: query
  *        name: limit
  *        schema:

--- a/src/routes/users-router.ts
+++ b/src/routes/users-router.ts
@@ -31,11 +31,19 @@ usersRouter.route("/users")
  *        name: sort
  *        schema:
  *          type: string
+ *          enum:
+ *            - user_id
+ *            - email
+ *            - first_name
+ *            - surname
  *        default: user_id
  *      - in: query
  *        name: order
  *        schema:
  *          type: string
+ *          enum:
+ *            - asc
+ *            - desc
  *        default: asc
  *      - in: query
  *        name: limit


### PR DESCRIPTION
### Summary

- Improved security of SQL queries in `selectCropsByPlotId`, `selectCropsBySubdivisionId`, `selectPlotsByOwner`, `selectSubdivisionsByPlotId`, and `selectAllUsers`
- Removed default `order` value from `selectCropsByPlotId`, `selectCropsBySubdivisionId`, `selectPlotsByOwner` and `selectSubdivisionsByPlotId`
- Updated `selectCropsByPlotId`, `selectCropsBySubdivisionId` and `selectPlotsByOwner` to sort results by `name` by default
- Updated `selectSubdivisionsByPlotId` to sort results by `type` by default
- Added enums to JSDoc annotations