### PR TITLE
Update user email conflict fix

### DIFF
--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -450,6 +450,32 @@ describe("PATCH /api/users/:user_id", () => {
     })
   })
 
+  test("PATCH:200 Does not flag an email conflict when the current email address matches the email address in the request body", async () => {
+
+    const newDetails: UserRequest = {
+      email: "john.smith@example.com",
+      first_name: "J",
+      surname: "Smith-Jones",
+      unit_system: UnitSystem.Metric
+    }
+
+    const { body } = await request(app)
+      .patch("/api/users/1")
+      .send(newDetails)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+
+    expect(body.user).toMatchObject<SecureUser>({
+      user_id: 1,
+      username: "carrot_king",
+      email: "john.smith@example.com",
+      first_name: "J",
+      surname: "Smith-Jones",
+      role: UserRole.Admin,
+      unit_system: UnitSystem.Metric
+    })
+  })
+
   test("PATCH:400 Responds with an error when the user_id parameter is not a positive integer", async () => {
 
     const newDetails: UserRequest = {

--- a/src/__tests__/utils/db-queries.test.ts
+++ b/src/__tests__/utils/db-queries.test.ts
@@ -14,7 +14,7 @@ describe("checkForEmailConflict", () => {
 
   test("When an email conflict is found, the promise is rejected", async () => {
 
-    await expect(checkForEmailConflict("john.smith@example.com")).rejects.toMatchObject<StatusResponse>({
+    await expect(checkForEmailConflict("john.smith@example.com", undefined)).rejects.toMatchObject<StatusResponse>({
       status: 409,
       message: "Conflict",
       details: "Email already exists"
@@ -23,7 +23,10 @@ describe("checkForEmailConflict", () => {
 
   test("When no email conflict is found, the promise resolves to be undefined", async () => {
 
-    await expect(checkForEmailConflict("foobar@foobar.com")).resolves.toBeUndefined()
+    await Promise.all([
+      expect(checkForEmailConflict("foobar@foobar.com", undefined)).resolves.toBeUndefined(),
+      expect(checkForEmailConflict("john.smith@example.com", 1)).resolves.toBeUndefined()
+    ])
   })
 })
 

--- a/src/models/register-models.ts
+++ b/src/models/register-models.ts
@@ -32,7 +32,7 @@ export const registerUser = async (
     })
   }
 
-  await checkForEmailConflict(email)
+  await checkForEmailConflict(email, undefined)
 
   const hashedPassword = await generateHash(password)
 

--- a/src/models/users-models.ts
+++ b/src/models/users-models.ts
@@ -2,7 +2,7 @@ import QueryString from "qs"
 import { db } from "../db"
 import { compareHash, generateHash } from "../middleware/security"
 import { StatusResponse } from "../types/response-types"
-import { PasswordUpdate, SecureUser } from "../types/user-types"
+import { PasswordUpdate, SecureUser, UserRequest } from "../types/user-types"
 import { checkForEmailConflict, fetchUserRole, searchForUserId, confirmUnitSystemIsValid, confirmUserRoleIsValid } from "../utils/db-queries"
 import { verifyPagination, verifyValueIsPositiveInt, verifyPermission, verifyQueryValue } from "../utils/verification"
 import format from "pg-format"
@@ -124,7 +124,7 @@ export const selectUserByUserId = async (
 export const updateUserByUserId = async (
   authUserId: number,
   user_id: number,
-  user: SecureUser
+  user: UserRequest
 ): Promise<SecureUser> => {
 
   await verifyValueIsPositiveInt(user_id)
@@ -133,7 +133,7 @@ export const updateUserByUserId = async (
 
   await verifyPermission(authUserId, user_id)
 
-  await checkForEmailConflict(user.email)
+  await checkForEmailConflict(user.email, user_id)
 
   const result = await db.query(`
     UPDATE users


### PR DESCRIPTION
### Summary

- Updates functionality for `checkForEmailConflict` to prevent 409 error when a user submits a PATCH request in which the email address on the request body matches the email address in the database.
- Updates test cases for `checkForEmailConflict` and `PATCH /api/users/:user_id`
- Updates args for `checkForEmailConflict` in `updateUserByUserId` and `registerUser`

> Fixes bug preventing users from updating their details when their email address remained unchanged.