### PR TITLE
Update password fix

### DIFF
--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -754,7 +754,7 @@ describe("PATCH /api/users/:user_id/password", () => {
 
     expect(body).toMatchObject<StatusResponse>({
       message: "Conflict",
-      details: "New password must not match old password"
+      details: "Old password and new password must be different"
     })
   })
 })

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -754,7 +754,7 @@ describe("PATCH /api/users/:user_id/password", () => {
 
     expect(body).toMatchObject<StatusResponse>({
       message: "Conflict",
-      details: "Old password and new password must be different"
+      details: "Old and new password values cannot be equal"
     })
   })
 })

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -644,6 +644,25 @@ describe("PATCH /api/users/:user_id/password", () => {
     })
   })
 
+  test("PATCH:400 Responds with an error when the new password is an empty string", async () => {
+
+    const passwordUpdate: PasswordUpdate = {
+      oldPassword: "carrots123",
+      newPassword: ""
+    }
+
+    const { body } = await request(app)
+      .patch("/api/users/1/password")
+      .send(passwordUpdate)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Bad Request",
+      details: "Empty string"
+    })
+  })
+
   test("PATCH:400 Responds with an error when the user_id is not a positive integer", async () => {
 
     const passwordUpdate: PasswordUpdate = {
@@ -717,6 +736,25 @@ describe("PATCH /api/users/:user_id/password", () => {
     expect(body).toMatchObject<StatusResponse>({
       message: "Not Found",
       details: "User not found"
+    })
+  })
+
+  test("PATCH:409 Responds with an error when the new password matches the old password", async () => {
+
+    const passwordUpdate: PasswordUpdate = {
+      oldPassword: "carrots123",
+      newPassword: "carrots123"
+    }
+
+    const { body } = await request(app)
+      .patch("/api/users/1/password")
+      .send(passwordUpdate)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(409)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Conflict",
+      details: "New password must not match old password"
     })
   })
 })

--- a/src/models/users-models.ts
+++ b/src/models/users-models.ts
@@ -231,7 +231,7 @@ export const updatePasswordByUserId = async (
     return Promise.reject({
       status: 409,
       message: "Conflict",
-      details: "New password must not match old password"
+      details: "Old password and new password must be different"
     })
   }
 

--- a/src/models/users-models.ts
+++ b/src/models/users-models.ts
@@ -231,7 +231,7 @@ export const updatePasswordByUserId = async (
     return Promise.reject({
       status: 409,
       message: "Conflict",
-      details: "Old password and new password must be different"
+      details: "Old and new password values cannot be equal"
     })
   }
 

--- a/src/models/users-models.ts
+++ b/src/models/users-models.ts
@@ -226,6 +226,15 @@ export const updatePasswordByUserId = async (
     })
   }
 
+  // Compare values once old password has been verified
+  if (oldPassword === newPassword) {
+    return Promise.reject({
+      status: 409,
+      message: "Conflict",
+      details: "New password must not match old password"
+    })
+  }
+
   const hashedPassword = await generateHash(newPassword)
 
   await db.query(`

--- a/src/routes/users-router.ts
+++ b/src/routes/users-router.ts
@@ -301,6 +301,12 @@ usersRouter.route("/users/:user_id")
  *          application/json:
  *            schema:
  *              $ref: "#/components/schemas/NotFound"
+ *      409:
+ *        description: Conflict
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/Conflict"
  */
 usersRouter.patch("/users/:user_id/password", verifyToken, patchPasswordByUserId)
 


### PR DESCRIPTION
### Summary

- Added check in `updatePasswordByUserId` to ensure old and new password cannot match and raise a 409 error
- Added corresponding test case for `PATCH /api/users/:user_id/password`
- Update JSDoc annotations

> Prevents users from updating their password without changing its value.