### PR TITLE
Get user admin perms

### DIFF
--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -381,6 +381,24 @@ describe("GET /api/users/:user_id", () => {
     })
   })
 
+  test("GET:200 An admin can retrieve another user's data", async () => {
+
+    const { body } = await request(app)
+      .get("/api/users/2")
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+
+    expect(body.user).toMatchObject<SecureUser>({
+      user_id: 2,
+      username: "peach_princess",
+      email: "olivia.jones@example.com",
+      first_name: "Olivia",
+      surname: "Jones",
+      role: UserRole.User,
+      unit_system: UnitSystem.Metric
+    })
+  })
+
   test("GET:400 Responds with an error when the user_id parameter is not a positive integer", async () => {
 
     const { body } = await request(app)
@@ -394,10 +412,19 @@ describe("GET /api/users/:user_id", () => {
     })
   })
 
-  test("GET:403 Responds with an error when the authenticated user attempts to retrieve another user's data", async () => {
+  test("GET:403 Responds with an error when a non-admin authenticated user attempts to retrieve another user's data", async () => {
+
+    const auth = await request(app)
+      .post("/api/login")
+      .send({
+        login: "peach_princess",
+        password: "Peaches123",
+      })
+
+    token = auth.body.token
 
     const { body } = await request(app)
-      .get("/api/users/2")
+      .get("/api/users/1")
       .set("Authorization", `Bearer ${token}`)
       .expect(403)
 

--- a/src/__tests__/utils/db-queries.test.ts
+++ b/src/__tests__/utils/db-queries.test.ts
@@ -3,6 +3,7 @@ import { db } from "../../db"
 import { seed } from "../../db/seeding/seed"
 import { checkForEmailConflict, checkForPlotNameConflict, checkForSubdivisionNameConflict, fetchCropOwnerId, fetchPlotOwnerId, fetchSubdivisionPlotId, fetchUserRole, searchForUserId, confirmCropCategoryIsValid, confirmPlotTypeIsValid, confirmSubdivisionTypeIsValid, confirmUnitSystemIsValid, confirmUserRoleIsValid, fetchCropNoteCropId, fetchIssueOwnerId } from "../../utils/db-queries"
 import { StatusResponse } from "../../types/response-types"
+import { UserRole } from "../../types/user-types"
 
 
 beforeEach(() => seed(data))
@@ -176,8 +177,8 @@ describe("fetchUserRole", () => {
   test("Returns the role of the user with the given user ID", async () => {
 
     await Promise.all([
-      expect(fetchUserRole(1)).resolves.toBe("admin"),
-      expect(fetchUserRole(2)).resolves.toBe("user"),
+      expect(fetchUserRole(1)).resolves.toBe(UserRole.Admin),
+      expect(fetchUserRole(2)).resolves.toBe(UserRole.User),
     ])
   })
 


### PR DESCRIPTION
### Summary

- Updated `selectUserByUserId` to allow admins to retrieve a single user's data
- Updated tests for `GET /api/users/:user_id`
- Replaced string values with `UserRole` enum values in user models and db query tests

> Allows admins to view a single user's data (previously only able to retrieve all).