### PR TITLE
Pin unpin plot update

### DIFF
--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -969,7 +969,7 @@ describe("PATCH /api/plots/:plot_id/pin", () => {
 
   test("PATCH:200 Responds with a success message when a plot is successfully pinned", async () => {
 
-    const toggle: { bool: boolean } = { bool: true }
+    const toggle: { isPinned: boolean } = { isPinned: true }
 
     const { body } = await request(app)
       .patch("/api/plots/4/pin")
@@ -983,23 +983,7 @@ describe("PATCH /api/plots/:plot_id/pin", () => {
     })
   })
 
-  test("PATCH:200 Responds with a success message when a plot is successfully unpinned", async () => {
-
-    const toggle: { bool: boolean } = { bool: true }
-
-    const { body } = await request(app)
-      .patch("/api/plots/1/pin")
-      .send(toggle)
-      .set("Authorization", `Bearer ${token}`)
-      .expect(200)
-
-    expect(body).toMatchObject<StatusResponse>({
-      message: "OK",
-      details: "Plot unpinned successfully"
-    })
-  })
-
-  test("PATCH:400 Responds with an error when the maximum number of plots are already pinned", async () => {
+  test("PATCH:400 Responds with an error when the plot is already pinned or the the maximum number of pinned plots has been reached", async () => {
 
     const fourthPlot: PlotRequest = {
       name: "John's Orchard",
@@ -1027,7 +1011,7 @@ describe("PATCH /api/plots/:plot_id/pin", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(201)
 
-    const toggle: { bool: boolean } = { bool: true }
+    const toggle: { isPinned: boolean } = { isPinned: true }
 
     await request(app)
       .patch("/api/plots/4/pin")
@@ -1049,13 +1033,13 @@ describe("PATCH /api/plots/:plot_id/pin", () => {
 
     expect(body).toMatchObject<StatusResponse>({
       message: "Bad Request",
-      details: "Pin limit reached"
+      details: "Plot already pinned or pin limit reached"
     })
   })
 
-  test("PATCH:400 Responds with an error when the value of bool is not true (boolean data type)", async () => {
+  test("PATCH:400 Responds with an error when the value of isPinned is not true", async () => {
 
-    const toggle: { bool: boolean } = { bool: false }
+    const toggle: { isPinned: boolean } = { isPinned: false }
 
     const { body } = await request(app)
       .patch("/api/plots/1/pin")
@@ -1072,7 +1056,7 @@ describe("PATCH /api/plots/:plot_id/pin", () => {
 
   test("PATCH:400 Responds with an error when the plot_id parameter is not a positive integer", async () => {
 
-    const toggle: { bool: boolean } = { bool: true }
+    const toggle: { isPinned: boolean } = { isPinned: true }
 
     const { body } = await request(app)
       .patch("/api/plots/foobar/pin")
@@ -1088,7 +1072,7 @@ describe("PATCH /api/plots/:plot_id/pin", () => {
 
   test("PATCH:403 Responds with an error when the plot does not belong to the authenticated user", async () => {
 
-    const toggle: { bool: boolean } = { bool: true }
+    const toggle: { isPinned: boolean } = { isPinned: true }
 
     const { body } = await request(app)
       .patch("/api/plots/2/pin")
@@ -1104,7 +1088,7 @@ describe("PATCH /api/plots/:plot_id/pin", () => {
 
   test("PATCH:404 Responds with an error when the plot does not exist", async () => {
 
-    const toggle: { bool: boolean } = { bool: true }
+    const toggle: { isPinned: boolean } = { isPinned: true }
 
     const { body } = await request(app)
       .patch("/api/plots/999/pin")

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -1102,3 +1102,104 @@ describe("PATCH /api/plots/:plot_id/pin", () => {
     })
   })
 })
+
+
+describe("PATCH /api/plots/:plot_id/unpin", () => {
+
+  test("PATCH:200 Responds with a success message when a plot is successfully unpinned", async () => {
+
+    const toggle: { isPinned: boolean } = { isPinned: false }
+
+    const { body } = await request(app)
+      .patch("/api/plots/1/unpin")
+      .send(toggle)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(200)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "OK",
+      details: "Plot unpinned successfully"
+    })
+  })
+
+  test("PATCH:400 Responds with an error when the plot is already unpinned", async () => {
+
+    const toggle: { isPinned: boolean } = { isPinned: false }
+
+    const { body } = await request(app)
+      .patch("/api/plots/4/unpin")
+      .send(toggle)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Bad Request",
+      details: "Plot already unpinned"
+    })
+  })
+
+  test("PATCH:400 Responds with an error when the value of isPinned is not false", async () => {
+
+    const toggle: { isPinned: boolean } = { isPinned: true }
+
+    const { body } = await request(app)
+      .patch("/api/plots/1/unpin")
+      .send(toggle)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Bad Request",
+      details: "Invalid boolean value"
+    })
+
+  })
+
+  test("PATCH:400 Responds with an error when the plot_id parameter is not a positive integer", async () => {
+
+    const toggle: { isPinned: boolean } = { isPinned: false }
+
+    const { body } = await request(app)
+      .patch("/api/plots/foobar/unpin")
+      .send(toggle)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(400)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Bad Request",
+      details: "Value must be a positive integer"
+    })
+  })
+
+  test("PATCH:403 Responds with an error when the plot does not belong to the authenticated user", async () => {
+
+    const toggle: { isPinned: boolean } = { isPinned: false }
+
+    const { body } = await request(app)
+      .patch("/api/plots/2/unpin")
+      .send(toggle)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(403)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Forbidden",
+      details: "Permission denied"
+    })
+  })
+
+  test("PATCH:404 Responds with an error when the plot does not exist", async () => {
+
+    const toggle: { isPinned: boolean } = { isPinned: false }
+
+    const { body } = await request(app)
+      .patch("/api/plots/999/unpin")
+      .send(toggle)
+      .set("Authorization", `Bearer ${token}`)
+      .expect(404)
+
+    expect(body).toMatchObject<StatusResponse>({
+      message: "Not Found",
+      details: "Plot not found"
+    })
+  })
+})

--- a/src/controllers/plots-controllers.ts
+++ b/src/controllers/plots-controllers.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Response } from "express"
-import { insertPlotByOwner, removePlotByPlotId, selectPinnedPlotsByOwner, selectPlotByPlotId, selectPlotsByOwner, updateIsPinnedByPlotId, updatePlotByPlotId } from "../models/plots-models"
+import { insertPlotByOwner, removePlotByPlotId, selectPinnedPlotsByOwner, selectPlotByPlotId, selectPlotsByOwner, setIsPinnedByPlotId, updatePlotByPlotId } from "../models/plots-models"
 import { ExtendedRequest } from "../types/auth-types"
 
 
@@ -93,14 +93,14 @@ export const deletePlotByPlotId = async (req: ExtendedRequest, res: Response, ne
 }
 
 
-export const patchIsPinnedByPlotId = async (req: ExtendedRequest, res: Response, next: NextFunction) => {
+export const pinPlotByPlotId = async (req: ExtendedRequest, res: Response, next: NextFunction) => {
 
   const authUserId = req.user!.user_id
 
   const { plot_id } = req.params
 
   try {
-    const response = await updateIsPinnedByPlotId(authUserId, +plot_id, req.body)
+    const response = await setIsPinnedByPlotId(authUserId, +plot_id, req.body)
     res.status(200).send(response)
   } catch (err) {
     next(err)

--- a/src/controllers/plots-controllers.ts
+++ b/src/controllers/plots-controllers.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Response } from "express"
-import { insertPlotByOwner, removePlotByPlotId, selectPinnedPlotsByOwner, selectPlotByPlotId, selectPlotsByOwner, setIsPinnedByPlotId, updatePlotByPlotId } from "../models/plots-models"
+import { insertPlotByOwner, removePlotByPlotId, selectPinnedPlotsByOwner, selectPlotByPlotId, selectPlotsByOwner, setIsPinnedByPlotId, unsetIsPinnedByPlotId, updatePlotByPlotId } from "../models/plots-models"
 import { ExtendedRequest } from "../types/auth-types"
 
 
@@ -101,6 +101,21 @@ export const pinPlotByPlotId = async (req: ExtendedRequest, res: Response, next:
 
   try {
     const response = await setIsPinnedByPlotId(authUserId, +plot_id, req.body)
+    res.status(200).send(response)
+  } catch (err) {
+    next(err)
+  }
+}
+
+
+export const unpinPlotByPlotId = async (req: ExtendedRequest, res: Response, next: NextFunction) => {
+
+  const authUserId = req.user!.user_id
+
+  const { plot_id } = req.params
+
+  try {
+    const response = await unsetIsPinnedByPlotId(authUserId, +plot_id, req.body)
     res.status(200).send(response)
   } catch (err) {
     next(err)

--- a/src/routes/plots-router.ts
+++ b/src/routes/plots-router.ts
@@ -1,6 +1,6 @@
 import { Router } from "express"
 import { verifyToken } from "../middleware/authentication"
-import { deletePlotByPlotId, getPinnedPlotsByOwner, getPlotByPlotId, getPlotsByOwner, patchPlotByPlotId, pinPlotByPlotId, postPlotByOwner } from "../controllers/plots-controllers"
+import { deletePlotByPlotId, getPinnedPlotsByOwner, getPlotByPlotId, getPlotsByOwner, patchPlotByPlotId, pinPlotByPlotId, postPlotByOwner, unpinPlotByPlotId } from "../controllers/plots-controllers"
 
 
 export const plotsRouter = Router()
@@ -400,7 +400,7 @@ plotsRouter.route("/plots/:plot_id/pin")
  *    security:
  *      - bearerAuth: []
  *    summary: Pin a plot
- *    description: Responds with a success message. If plot is already pinned, the maximum number of pinned plots has been reached, or the plot_id parameter is invalid, the server responds with an error. Permission is denied when the plot does not belong to the user.
+ *    description: Responds with a success message. If the plot is already pinned, the maximum number of pinned plots has been reached, or the plot_id parameter is invalid, the server responds with an error. Permission is denied when the plot does not belong to the user.
  *    tags: [Plots]
  *    parameters:
  *      - in: path
@@ -452,3 +452,67 @@ plotsRouter.route("/plots/:plot_id/pin")
  *              $ref: "#/components/schemas/NotFound"
  */
   .patch(verifyToken, pinPlotByPlotId)
+
+
+plotsRouter.route("/plots/:plot_id/unpin")
+
+
+/**
+ * @swagger
+ * /api/plots/{plot_id}/unpin:
+ *  patch:
+ *    security:
+ *      - bearerAuth: []
+ *    summary: Unpin a plot
+ *    description: Responds with a success message. If plot is already unpinned or the plot_id parameter is invalid, the server responds with an error. Permission is denied when the plot does not belong to the user.
+ *    tags: [Plots]
+ *    parameters:
+ *      - in: path
+ *        name: plot_id
+ *        required: true
+ *        schema:
+ *          type: integer
+ *    requestBody:
+ *      required: true
+ *      content:
+ *        application/json:
+ *          schema:
+ *            type: object
+ *            properties:
+ *              isPinned:
+ *                type: boolean
+ *                example: false
+ *    responses:
+ *      200:
+ *        description: OK
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: object
+ *              properties:
+ *                message:
+ *                  type: string
+ *                  example: OK
+ *                details:
+ *                  type: string
+ *                  example: Plot unpinned successfully
+ *      400:
+ *        description: Bad Request
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/BadRequest"
+ *      403:
+ *        description: Forbidden
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/Forbidden"
+ *      404:
+ *        description: Not Found
+ *        content:
+ *          application/json:
+ *            schema:
+ *              $ref: "#/components/schemas/NotFound"
+ */
+  .patch(verifyToken, unpinPlotByPlotId)

--- a/src/routes/plots-router.ts
+++ b/src/routes/plots-router.ts
@@ -1,6 +1,6 @@
 import { Router } from "express"
 import { verifyToken } from "../middleware/authentication"
-import { deletePlotByPlotId, getPinnedPlotsByOwner, getPlotByPlotId, getPlotsByOwner, patchIsPinnedByPlotId, patchPlotByPlotId, postPlotByOwner } from "../controllers/plots-controllers"
+import { deletePlotByPlotId, getPinnedPlotsByOwner, getPlotByPlotId, getPlotsByOwner, patchPlotByPlotId, pinPlotByPlotId, postPlotByOwner } from "../controllers/plots-controllers"
 
 
 export const plotsRouter = Router()
@@ -399,8 +399,8 @@ plotsRouter.route("/plots/:plot_id/pin")
  *  patch:
  *    security:
  *      - bearerAuth: []
- *    summary: Pin or unpin a plot
- *    description: Responds with a success message. If the maximum number of plots are already pinned or the plot_id parameter is invalid, the server responds with an error. Permission is denied when the plot does not belong to the user.
+ *    summary: Pin a plot
+ *    description: Responds with a success message. If plot is already pinned, the maximum number of pinned plots has been reached, or the plot_id parameter is invalid, the server responds with an error. Permission is denied when the plot does not belong to the user.
  *    tags: [Plots]
  *    parameters:
  *      - in: path
@@ -415,7 +415,7 @@ plotsRouter.route("/plots/:plot_id/pin")
  *          schema:
  *            type: object
  *            properties:
- *              bool:
+ *              isPinned:
  *                type: boolean
  *                example: true
  *    responses:
@@ -428,17 +428,10 @@ plotsRouter.route("/plots/:plot_id/pin")
  *              properties:
  *                message:
  *                  type: string
+ *                  example: OK
  *                details:
  *                  type: string
- *            examples:
- *              Plot pinned:
- *                value:
- *                  message: OK
- *                  details: Plot pinned successfully
- *              Plot unpinned:
- *                value:
- *                  message: OK
- *                  details: Plot unpinned successfully
+ *                  example: Plot pinned successfully
  *      400:
  *        description: Bad Request
  *        content:
@@ -458,4 +451,4 @@ plotsRouter.route("/plots/:plot_id/pin")
  *            schema:
  *              $ref: "#/components/schemas/NotFound"
  */
-  .patch(verifyToken, patchIsPinnedByPlotId)
+  .patch(verifyToken, pinPlotByPlotId)


### PR DESCRIPTION
### Summary

- Replaced single endpoint to pin / unpin a plot with two separate routes.
- Replaced `patchIsPinnedByPlotId` controller with two separate controller to pin and unpin plots.
- Replaced `updateIsPinnedByPlotId` model with two separate models: `setIsPinnedByPlotId` and `unsetIsPinnedByPlotId`.

> Update replaces problematic toggle in previous `updateIsPinnedByPlotId` model with separate, RESTful endpoints.