### PR TITLE
Pin / unpin plot response body

### DIFF
--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -963,9 +963,9 @@ describe("DELETE /api/plots/:plot_id", () => {
 })
 
 
-describe("PATCH /api/plots/:plot_id/pin", () => {
+describe.only("PATCH /api/plots/:plot_id/pin", () => {
 
-  test("PATCH:200 Responds with a success message when a plot is successfully pinned", async () => {
+  test("PATCH:200 Responds with an updated plot object", async () => {
 
     const toggle: { isPinned: boolean } = { isPinned: true }
 
@@ -975,9 +975,15 @@ describe("PATCH /api/plots/:plot_id/pin", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    expect(body).toMatchObject<StatusResponse>({
-      message: "OK",
-      details: "Plot pinned successfully"
+    expect(body.plot).toMatchObject<Plot>({
+      plot_id: 4,
+      owner_id: 1,
+      name: "John's New Allotment",
+      type: "Allotment",
+      description: "A second allotment",
+      location: "Farmville",
+      area: 40,
+      is_pinned: true
     })
   })
 

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -1110,7 +1110,7 @@ describe("PATCH /api/plots/:plot_id/pin", () => {
 
 describe("PATCH /api/plots/:plot_id/unpin", () => {
 
-  test("PATCH:200 Responds with a success message when a plot is successfully unpinned", async () => {
+  test("PATCH:200 Responds with an updated plot object", async () => {
 
     const toggle: { isPinned: boolean } = { isPinned: false }
 

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -1108,7 +1108,7 @@ describe("PATCH /api/plots/:plot_id/pin", () => {
 })
 
 
-describe.only("PATCH /api/plots/:plot_id/unpin", () => {
+describe("PATCH /api/plots/:plot_id/unpin", () => {
 
   test("PATCH:200 Responds with a success message when a plot is successfully unpinned", async () => {
 

--- a/src/__tests__/plots.test.ts
+++ b/src/__tests__/plots.test.ts
@@ -963,7 +963,7 @@ describe("DELETE /api/plots/:plot_id", () => {
 })
 
 
-describe.only("PATCH /api/plots/:plot_id/pin", () => {
+describe("PATCH /api/plots/:plot_id/pin", () => {
 
   test("PATCH:200 Responds with an updated plot object", async () => {
 
@@ -1108,7 +1108,7 @@ describe.only("PATCH /api/plots/:plot_id/pin", () => {
 })
 
 
-describe("PATCH /api/plots/:plot_id/unpin", () => {
+describe.only("PATCH /api/plots/:plot_id/unpin", () => {
 
   test("PATCH:200 Responds with a success message when a plot is successfully unpinned", async () => {
 
@@ -1120,9 +1120,15 @@ describe("PATCH /api/plots/:plot_id/unpin", () => {
       .set("Authorization", `Bearer ${token}`)
       .expect(200)
 
-    expect(body).toMatchObject<StatusResponse>({
-      message: "OK",
-      details: "Plot unpinned successfully"
+    expect(body.plot).toMatchObject<Plot>({
+      plot_id: 1,
+      owner_id: 1,
+      name: "John's Garden",
+      type: "Garden",
+      description: "A vegetable garden",
+      location: "Farmville",
+      area: 100,
+      is_pinned: false
     })
   })
 

--- a/src/controllers/plots-controllers.ts
+++ b/src/controllers/plots-controllers.ts
@@ -100,8 +100,8 @@ export const pinPlotByPlotId = async (req: ExtendedRequest, res: Response, next:
   const { plot_id } = req.params
 
   try {
-    const response = await setIsPinnedByPlotId(authUserId, +plot_id, req.body)
-    res.status(200).send(response)
+    const plot = await setIsPinnedByPlotId(authUserId, +plot_id, req.body)
+    res.status(200).send({ plot })
   } catch (err) {
     next(err)
   }

--- a/src/controllers/plots-controllers.ts
+++ b/src/controllers/plots-controllers.ts
@@ -115,8 +115,8 @@ export const unpinPlotByPlotId = async (req: ExtendedRequest, res: Response, nex
   const { plot_id } = req.params
 
   try {
-    const response = await unsetIsPinnedByPlotId(authUserId, +plot_id, req.body)
-    res.status(200).send(response)
+    const plot = await unsetIsPinnedByPlotId(authUserId, +plot_id, req.body)
+    res.status(200).send({ plot })
   } catch (err) {
     next(err)
   }

--- a/src/models/plots-models.ts
+++ b/src/models/plots-models.ts
@@ -298,7 +298,7 @@ export const setIsPinnedByPlotId = async (
   authUserId: number,
   plot_id: number,
   toggle: { isPinned: boolean }
-): Promise<StatusResponse> => {
+): Promise<Plot> => {
 
   await verifyValueIsPositiveInt(plot_id)
 
@@ -340,10 +340,7 @@ export const setIsPinnedByPlotId = async (
     })
   }
 
-  return {
-    message: "OK",
-    details: "Plot pinned successfully"
-  }
+  return result.rows[0]
 }
 
 

--- a/src/models/plots-models.ts
+++ b/src/models/plots-models.ts
@@ -4,7 +4,6 @@ import format from "pg-format"
 import { ExtendedPlot, Plot, PlotRequest } from "../types/plot-types"
 import { checkForPlotNameConflict, fetchPlotOwnerId, searchForUserId, confirmPlotTypeIsValid } from "../utils/db-queries"
 import { verifyPermission, verifyValueIsPositiveInt, verifyPagination, verifyQueryValue } from "../utils/verification"
-import { StatusResponse } from "../types/response-types"
 import { QueryResult } from "pg"
 import { Count } from "../types/aggregation-types"
 
@@ -348,7 +347,7 @@ export const unsetIsPinnedByPlotId = async (
   authUserId: number,
   plot_id: number,
   toggle: { isPinned: boolean }
-): Promise<StatusResponse> => {
+): Promise<Plot> => {
 
   await verifyValueIsPositiveInt(plot_id)
 
@@ -383,8 +382,5 @@ export const unsetIsPinnedByPlotId = async (
     })
   }
 
-  return {
-    message: "OK",
-    details: "Plot unpinned successfully"
-  }
+  return result.rows[0]
 }

--- a/src/routes/plots-router.ts
+++ b/src/routes/plots-router.ts
@@ -460,7 +460,7 @@ plotsRouter.route("/plots/:plot_id/unpin")
  *    security:
  *      - bearerAuth: []
  *    summary: Unpin a plot
- *    description: Responds with a success message. If plot is already unpinned or the plot_id parameter is invalid, the server responds with an error. Permission is denied when the plot does not belong to the user.
+ *    description: Responds with an updated plot object. If plot is already unpinned or the plot_id parameter is invalid, the server responds with an error. Permission is denied when the plot does not belong to the user.
  *    tags: [Plots]
  *    parameters:
  *      - in: path
@@ -486,12 +486,8 @@ plotsRouter.route("/plots/:plot_id/unpin")
  *            schema:
  *              type: object
  *              properties:
- *                message:
- *                  type: string
- *                  example: OK
- *                details:
- *                  type: string
- *                  example: Plot unpinned successfully
+ *                plot:
+ *                  $ref: "#/components/schemas/Plot"
  *      400:
  *        description: Bad Request
  *        content:

--- a/src/routes/plots-router.ts
+++ b/src/routes/plots-router.ts
@@ -400,7 +400,7 @@ plotsRouter.route("/plots/:plot_id/pin")
  *    security:
  *      - bearerAuth: []
  *    summary: Pin a plot
- *    description: Responds with a success message. If the plot is already pinned, the maximum number of pinned plots has been reached, or the plot_id parameter is invalid, the server responds with an error. Permission is denied when the plot does not belong to the user.
+ *    description: Responds with an updated plot object. If the plot is already pinned, the maximum number of pinned plots has been reached, or the plot_id parameter is invalid, the server responds with an error. Permission is denied when the plot does not belong to the user.
  *    tags: [Plots]
  *    parameters:
  *      - in: path
@@ -426,12 +426,8 @@ plotsRouter.route("/plots/:plot_id/pin")
  *            schema:
  *              type: object
  *              properties:
- *                message:
- *                  type: string
- *                  example: OK
- *                details:
- *                  type: string
- *                  example: Plot pinned successfully
+ *                plot:
+ *                  $ref: "#/components/schemas/Plot"
  *      400:
  *        description: Bad Request
  *        content:


### PR DESCRIPTION
### Summary

- Updated `setIsPinnedByPlotId` and `unsetIsPinnedByPlotId` to return an updated plot object rather than a success message
- Updated `pinPlotByPlotId` and `unpinPlotByPlotId` to send a `plot` object on the response body
- Updated JSDoc annotations
- Updated test cases